### PR TITLE
Show the DBZ configurator properties on the review step

### DIFF
--- a/packages/machines/src/CreationWizard/ReviewMachine.ts
+++ b/packages/machines/src/CreationWizard/ReviewMachine.ts
@@ -117,11 +117,20 @@ export const reviewMachine = createMachine<typeof reviewMachineModel>(
 );
 
 function dataToPrettyString(data: unknown) {
+  const dataVal = data instanceof Map ? mapToObject(data) : data;
   try {
-    return JSON.stringify(data, null, 2);
+    return JSON.stringify(dataVal, null, 2);
   } catch (e) {
     return '';
   }
+}
+
+function mapToObject(inputMap: Map<string, unknown>) {
+  const obj = {} as { [key: string]: unknown };
+  inputMap.forEach((value, key) => {
+    obj[key] = value;
+  });
+  return obj;
 }
 
 function verifyData(


### PR DESCRIPTION
Added the handling of `Map` type `connectorConfiguration` context value in case of DBZ.

Screenshot 
![image](https://user-images.githubusercontent.com/8264372/121684562-79cc9a80-cadc-11eb-85c1-e1be59e7a3c2.png)

Fixes https://github.com/bf2fc6cc711aee1a0c2a/cos-ui/issues/18