### PR TITLE
i18n: Fix translation file loading path in case of Module Federation

### DIFF
--- a/packages/app/src/i18n/index.ts
+++ b/packages/app/src/i18n/index.ts
@@ -22,7 +22,7 @@ i18n
     // Commenting it as we have fallbackLng for case of language detected as en-GB or en-US
     // supportedLngs: ['en','it'],
     backend: {
-      loadPath: `locales/{{lng}}/{{ns}}.json`,
+      loadPath: `${__webpack_public_path__}locales/{{lng}}/{{ns}}.json`,
     },
     fallbackLng: 'en',
     load: 'all',

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -11,3 +11,4 @@ declare module "*.svg" {
 
 declare function __webpack_init_sharing__(s: string): Promise<void>;
 declare const __webpack_share_scopes__: {[key: string]: any};
+declare const __webpack_public_path__: string;


### PR DESCRIPTION
Fix the translation file loading path, now it is loaded from the same path where all the rest `cos-ui` ("fed-mods.json") federated components are being loaded.

Screenshot form "application-services-ui"
![image](https://user-images.githubusercontent.com/8264372/121902450-f661b200-cd44-11eb-8829-6012f50fecd4.png)
