### PR TITLE
Add delete connector confirmation

### DIFF
--- a/apps/cos-ui/src/locales/en/public.json
+++ b/apps/cos-ui/src/locales/en/public.json
@@ -13,5 +13,10 @@
   "Deletion in progress": "Deletion in progress",
   "loading": "Loading",
   "selectOcmCluster": "Select OCM cluster",
-  "createConnectors": "Create connector"
+  "createConnectors": "Create connector",
+  "deleteConnector": "Delete connector?",
+  "deleteConfirmMessage": "Connector <1>{{connectorName}}</1> will be deleted.",
+  "deleteTypeNameMessage": "Type <1>{{connectorName}}</1> to confirm the deletion.",
+  "delete": "Delete",
+  "cancel": "Cancel"
 }

--- a/apps/cos-ui/src/locales/it/public.json
+++ b/apps/cos-ui/src/locales/it/public.json
@@ -13,5 +13,10 @@
   "Deletion in progress": "Deletion in progress",
   "loading": "Caricamento in corso",
   "selectOcmCluster": "Seleziona cluster OCM",
-  "createConnectors": "Crea connettore"
+  "createConnectors": "Crea connettore",
+  "deleteConnector": "Eliminare il connettore?",
+  "deleteConfirmMessage": "Il connettore <1>{{connectorName}}</1> verrà eliminato.",
+  "deleteTypeNameMessage": "Digitare <1>{{connectorName}}</1> per confermare l'eliminazione.",
+  "delete": "Elimina",
+  "cancel": "Annulla"
 }

--- a/packages/app/src/ConnectorTableView.tsx
+++ b/packages/app/src/ConnectorTableView.tsx
@@ -46,6 +46,7 @@ import {
   Thead,
   Tr,
 } from '@patternfly/react-table';
+import { DeleteConnectorConfirmDialog } from './DeleteConnectorConfirmDialog';
 
 export type ConnectorTableViewProps = {
   data: PaginatedApiResponse<ConnectorMachineActorRef> | undefined;
@@ -118,6 +119,20 @@ export const ConnectorRow: FunctionComponent<ConnectorRowProps> = ({
     onDelete,
   } = useConnector(connectorRef);
 
+  const [
+    showDeleteConnectorConfirm,
+    setShowDeleteConnectorConfirm,
+  ] = React.useState(false);
+
+  const doCancelDeleteConnector = () => {
+    setShowDeleteConnectorConfirm(false);
+  };
+
+  const doDeleteConnector = () => {
+    setShowDeleteConnectorConfirm(false);
+    onDelete();
+  };
+
   const actions: IActions = [
     {
       title: 'Start',
@@ -131,7 +146,7 @@ export const ConnectorRow: FunctionComponent<ConnectorRowProps> = ({
     },
     {
       title: 'Delete',
-      onClick: onDelete,
+      onClick: () => setShowDeleteConnectorConfirm(true),
       isDisabled: !canDelete,
     },
     {
@@ -156,38 +171,49 @@ export const ConnectorRow: FunctionComponent<ConnectorRowProps> = ({
 
   const getStatusLabel = (status: string) =>
     statusOptions.find(s => s.value === status)?.label || status;
-
+      
   return (
-    <Tr
-      onClick={event => {
-        // send the event only if the click didn't happen on the actions button
-        if ((event.target as any | undefined)?.type !== 'button') {
-          onClick(connector);
-        }
-      }}
-      className={css(
-        'pf-c-table-row__item',
-        'pf-m-selectable',
-        activeRow && activeRow === connector.id && 'pf-m-selected'
-      )}
-    >
-      <Td dataLabel={t('id')}>{connector.id}</Td>
-      <Td dataLabel={t('name')}>{connector.metadata?.name}</Td>
-      <Td dataLabel={t('type')}>{connector.connector_type_id}</Td>
-      <Td dataLabel={t('category')}>TODO: MISSING</Td>
-      <Td dataLabel={t('status')}>
-        <Flex>
-          <FlexItem spacer={{ default: 'spacerSm' }}>
-            <ConnectorStatusIcon
-              id={connector.id!}
-              status={connector.status!}
-            />
-          </FlexItem>
-          <FlexItem>{getStatusLabel(connector.status!)}</FlexItem>
-        </Flex>
-      </Td>
-      <Td actions={{ items: actions }} />
-    </Tr>
+    <>
+      <DeleteConnectorConfirmDialog
+        connectorName={connector.metadata?.name}
+        i18nCancel={t('cancel')}
+        i18nDelete={t('delete')}
+        i18nTitle={t('deleteConnector')}
+        showDialog={showDeleteConnectorConfirm}
+        onCancel={doCancelDeleteConnector}
+        onConfirm={doDeleteConnector}
+      />
+      <Tr
+        onClick={event => {
+          // send the event only if the click didn't happen on the actions button
+          if ((event.target as any | undefined)?.type !== 'button') {
+            onClick(connector);
+          }
+        }}
+        className={css(
+          'pf-c-table-row__item',
+          'pf-m-selectable',
+          activeRow && activeRow === connector.id && 'pf-m-selected'
+        )}
+      >
+        <Td dataLabel={t('id')}>{connector.id}</Td>
+        <Td dataLabel={t('name')}>{connector.metadata?.name}</Td>
+        <Td dataLabel={t('type')}>{connector.connector_type_id}</Td>
+        <Td dataLabel={t('category')}>TODO: MISSING</Td>
+        <Td dataLabel={t('status')}>
+          <Flex>
+            <FlexItem spacer={{ default: 'spacerSm' }}>
+              <ConnectorStatusIcon
+                id={connector.id!}
+                status={connector.status!}
+              />
+            </FlexItem>
+            <FlexItem>{getStatusLabel(connector.status!)}</FlexItem>
+          </Flex>
+        </Td>
+        <Td actions={{ items: actions }} />
+      </Tr>
+    </>
   );
 };
 

--- a/packages/app/src/DeleteConnectorConfirmDialog.tsx
+++ b/packages/app/src/DeleteConnectorConfirmDialog.tsx
@@ -1,0 +1,96 @@
+import React, {useEffect} from 'react';
+import {
+  Modal,
+  Button,
+  Stack,
+  StackItem,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import { Trans } from 'react-i18next';
+
+export interface IDeleteConnectorConfirmDialogProps {
+  connectorName: string | undefined;
+  i18nCancel: string;
+  i18nDelete: string;
+  i18nTitle: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  showDialog: boolean;
+}
+
+/**
+ * A modal dialog to display confirmation for connector deletion.
+ */
+export const DeleteConnectorConfirmDialog: React.FunctionComponent<IDeleteConnectorConfirmDialogProps> = ({
+  connectorName,
+  i18nCancel,
+  i18nDelete,
+  i18nTitle,
+  onCancel,
+  onConfirm,
+  showDialog,
+}) => {
+
+  const [nameValue, setNameValue] = React.useState("");
+  const [canDelete, setCanDelete] = React.useState(false);
+
+  // enable delete button if entered name matches
+  useEffect(() => {
+    setCanDelete(nameValue === connectorName);
+  }, [nameValue]);
+
+  const onCancelDelete = () => {
+    setNameValue("");
+    onCancel();
+  }
+
+  const onConfirmDelete = () => {
+    setNameValue("");
+    onConfirm();
+  }
+  
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={i18nTitle}
+      titleIconVariant="warning"
+      isOpen={showDialog}
+      onClose={onCancel}
+      actions={[
+        <Button
+          key="confirm"
+          variant="danger"
+          isDisabled={!canDelete}
+          onClick={onConfirmDelete}
+        >
+          {i18nDelete}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onCancelDelete}>
+          {i18nCancel}
+        </Button>,
+      ]}
+    >
+      <Stack>
+        <StackItem>
+          <Trans i18nKey="deleteConfirmMessage">
+            Connector <strong>{{ connectorName }}</strong> will be deleted.
+          </Trans>
+        </StackItem>
+        <StackItem>
+          <Trans i18nKey="deleteTypeNameMessage">
+            Type <strong>{{connectorName}}</strong> to confirm the deletion.
+          </Trans>
+        </StackItem>
+        <StackItem>
+          <TextInput
+            value={nameValue}
+            type="text"
+            onChange={setNameValue}
+            aria-label="name input"
+          />
+        </StackItem>
+      </Stack>
+    </Modal>
+  );
+};


### PR DESCRIPTION
Adding dialog for user to confirm deletion of a connector.  The user must enter the connector name to enable the delete button, to avoid accidental delete.

![DeleteConfirmation](https://user-images.githubusercontent.com/1820403/123168726-fa28bf00-d43d-11eb-82ec-7eb82117830e.png)

Fixes #10 