### PR TITLE
MGDCTRS-566: help text/tooltips for Camel forms

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -119,5 +119,6 @@
   "preparing": "Creation in progress",
   "deprovision": "Deletion in progress",
   "deleted": "Deletion in progress",
-  "Topic ": "Topic"
+  "Topic ": "Topic",
+  "More info for {{name}}": "More info for {{name}}"
 }

--- a/locales/it/public.json
+++ b/locales/it/public.json
@@ -119,5 +119,6 @@
   "preparing": "Creation in progress",
   "deprovision": "Deletion in progress",
   "deleted": "Deletion in progress",
-  "Topic ": "Topic"
+  "Topic ": "Topic",
+  "More info for {{name}}": "Maggiori informazioni per {{name}}"
 }

--- a/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
+++ b/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
@@ -1,0 +1,56 @@
+import { Popover } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import JSONSchemaBridge from 'uniforms-bridge-json-schema';
+import { Translation } from 'react-i18next';
+import React from 'react';
+
+/**
+ * Returns an example string formatted (not localized) for the form or undefined if the field has no example text
+ * @param exampleText 
+ * @returns 
+ */
+const getExampleText = (exampleText: string) => (typeof (exampleText) !== 'undefined' ? (
+  `Example: ${exampleText}`
+) : undefined)
+
+/**
+ * Returns a label tooltip element for the form or undefined if the field has no description
+ * @param name 
+ * @param content 
+ * @returns 
+ */
+const getLabelIcon = (name: string, content: string) =>
+  typeof (content) !== 'undefined' ?
+    (<Translation>
+      {t => <Popover bodyContent={content}>
+        <button
+          type="button"
+          aria-label={t('More info for {{name}}', { name })}
+          onClick={e => e.preventDefault()}
+          aria-describedby="form-group-label-info"
+          className="pf-c-form__group-label-help"
+        ><HelpIcon noVerticalAlign /></button>
+      </Popover>}
+    </Translation>) : undefined;
+
+/**
+ * CustomJsonSchemaBridge generates the appropriate attributes for uniforms-patternfly
+ * based on the incoming model data
+ */
+export class CustomJsonSchemaBridge extends JSONSchemaBridge {
+
+  constructor(schema: any, validator: any) {
+    super(schema, validator);
+  }
+
+  getField(name: string): Record<string, any> {
+    const field = super.getField(name);
+    const { description, example, title, ...props } = field;
+    return {
+      helperText: getExampleText(example),
+      labelIcon: getLabelIcon(title, description),
+      title,
+      ...props
+    };
+  }
+}

--- a/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
+++ b/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
@@ -1,10 +1,10 @@
+import { CustomJsonSchemaBridge } from './CustomJsonSchemaBridge';
 import { Resolver } from '@stoplight/json-ref-resolver';
 import { createValidator } from '@utils/createValidator';
 import { ValidateFunction } from 'ajv';
 import _ from 'lodash';
 import React, { FunctionComponent } from 'react';
 import { AutoForm, ValidatedQuickForm } from 'uniforms';
-import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { AutoField } from 'uniforms-patternfly';
 
 import { Grid } from '@patternfly/react-core';
@@ -31,7 +31,7 @@ export const JsonSchemaConfigurator: FunctionComponent<JsonSchemaConfiguratorPro
     } catch (e) {}
 
     const schemaValidator = createValidator(schema);
-    const bridge = new JSONSchemaBridge(schema, schemaValidator);
+    const bridge = new CustomJsonSchemaBridge(schema, schemaValidator);
     const { required } = bridge.schema;
 
     async function getDataShape(): Promise<any> {


### PR DESCRIPTION
Add a custom JSON schema bridge to further customize field definitions
and add appropriate field definitions for uniforms-patternfly.

![image](https://user-images.githubusercontent.com/351660/158667662-7898b684-efcb-4f58-a3aa-356aaeef7aa1.png)

I would appreciate any correction on the translation :smile: 