### PR TITLE
chore: Check the repo owner in job, fixes #417

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,12 +1,11 @@
 # Workflow name
 name: 'Chromatic Deployment'
-
 # Event for the workflow
 on: push
-
 # List of jobs
 jobs:
   test:
+    if: github.repository_owner == 'bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps


### PR DESCRIPTION
This should prevent the Chromatic action from running on a fork should
the fork owner decide to keep their fork up to date.

Tested locally with act and seems to work but kind of hard to test locally.  This job should still run against the main branch after merging, if it doesn't then we can revert and I can look at another way.