### PR TITLE
MGDCTRS-20: fix: Ensure the query is preserved

### DIFF
--- a/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
@@ -63,9 +63,7 @@ export function ConnectorTypesGallery() {
     loading,
     error,
     noResults,
-    // results,
     queryEmpty,
-    // queryResults,
     duplicateMode,
     connectorTypeDetails,
     firstRequest,
@@ -346,7 +344,12 @@ const ConnectorTypesToolbar: FunctionComponent<ConnectorTypesToolbarProps> = ({
       </ToolbarToggleGroup>
       {!duplicateMode && (
         <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
-          <ConnectorTypesPagination isCompact />
+          <ConnectorTypesPagination
+            isCompact
+            onChange={(page, size) =>
+              onQuery({ page, size, query: request.query || {} })
+            }
+          />
         </ToolbarItem>
       )}
     </>
@@ -366,16 +369,17 @@ const ConnectorTypesToolbar: FunctionComponent<ConnectorTypesToolbarProps> = ({
 
 type ConnectorTypesPaginationProps = {
   isCompact?: boolean;
+  onChange: (page: number, size: number) => void;
 };
 const ConnectorTypesPagination: FunctionComponent<ConnectorTypesPaginationProps> =
-  ({ isCompact = false }) => {
-    const { request, response, onQuery } = useConnectorTypesMachine();
+  ({ isCompact = false, onChange }) => {
+    const { request, response } = useConnectorTypesMachine();
     return (
       <Pagination
         itemCount={response?.total || 0}
         page={request.page}
         perPage={request.size}
-        onChange={(page, size) => onQuery({ page, size })}
+        onChange={onChange}
         isCompact={isCompact}
       />
     );


### PR DESCRIPTION
This ensures that the name/category query is preserved when interacting
with the pagination controls on the connector type selection page.

So, now it's possible to look at that 2nd page of AWS results for example:

![image](https://user-images.githubusercontent.com/351660/161763052-5da80591-a505-480a-8204-73a84a1f507d.png)
