### PR TITLE
MGDCTRS-720 feat: add a failure reason field

### DIFF
--- a/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
+++ b/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
@@ -22,10 +22,6 @@ import {
   TabTitleText,
   Text,
   TextContent,
-  TextList,
-  TextListItem,
-  TextListItemVariants,
-  TextListVariants,
   TextVariants,
   Title,
   TitleSizes,
@@ -33,6 +29,7 @@ import {
 
 import { Connector } from '@rhoas/connector-management-sdk';
 
+import { ConnectorInfoTextList } from '../ConnectorInfoTextList/ConnectorInfoTextList';
 import './ConnectorDrawer.css';
 
 export type ConnectorDrawerProps = {
@@ -61,6 +58,7 @@ export const ConnectorDrawer: FunctionComponent<ConnectorDrawerProps> = ({
               createdAt={new Date(connector.created_at!)}
               modifiedAt={new Date(connector.modified_at!)}
               status={connector.status?.state!}
+              error={connector.status?.error}
               onClose={onClose}
             />
           ) : undefined
@@ -82,6 +80,7 @@ export type ConnectorDrawerPanelContentProps = {
   createdAt: Date;
   modifiedAt: Date;
   status: string;
+  error?: string;
   onClose: () => void;
 };
 
@@ -96,6 +95,7 @@ export const ConnectorDrawerPanelContent: FunctionComponent<ConnectorDrawerPanel
     createdAt,
     modifiedAt,
     status,
+    error,
     onClose,
   }) => {
     const { t } = useTranslation();
@@ -104,21 +104,6 @@ export const ConnectorDrawerPanelContent: FunctionComponent<ConnectorDrawerPanel
     const selectActiveKey = (_: MouseEvent, eventKey: string | number) => {
       setActiveTabKey(eventKey);
     };
-
-    const textListItem = (title: string, value?: ReactNode) => (
-      <>
-        {value && (
-          <>
-            <TextListItem component={TextListItemVariants.dt}>
-              {title}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {value}
-            </TextListItem>
-          </>
-        )}
-      </>
-    );
 
     return (
       <DrawerPanelContent widths={{ default: 'width_50' }}>
@@ -157,34 +142,17 @@ export const ConnectorDrawerPanelContent: FunctionComponent<ConnectorDrawerPanel
               title={<TabTitleText>{t('Details')}</TabTitleText>}
             >
               <div className="connector-drawer__tab-content">
-                <TextContent>
-                  <TextList component={TextListVariants.dl}>
-                    {textListItem('Connector', name)}
-                    {textListItem('Connector Id', id)}
-                    {textListItem('Bootstrap server', bootstrapServer)}
-                    {textListItem('Kafka_instance', kafkaId)}
-                    {textListItem('Deployment namespace', namespaceId)}
-                    {textListItem('Owner', owner)}
-                    {textListItem(
-                      'Time created',
-                      <time
-                        title={t('{{date}}', { date: createdAt })}
-                        dateTime={createdAt.toISOString()}
-                      >
-                        {t('{{ date, ago }}', { date: createdAt })}
-                      </time>
-                    )}
-                    {textListItem(
-                      'Time updated',
-                      <time
-                        title={t('{{date}}', { date: modifiedAt })}
-                        dateTime={modifiedAt.toISOString()}
-                      >
-                        {t('{{ date, ago }}', { date: modifiedAt })}
-                      </time>
-                    )}
-                  </TextList>
-                </TextContent>
+                <ConnectorInfoTextList
+                  name={name}
+                  id={id}
+                  bootstrapServer={bootstrapServer}
+                  kafkaId={kafkaId}
+                  namespaceId={namespaceId}
+                  owner={owner}
+                  createdAt={createdAt}
+                  modifiedAt={modifiedAt}
+                  error={error}
+                />
               </div>
             </Tab>
             {/* <Tab

--- a/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
+++ b/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
@@ -1,0 +1,85 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
+
+export type ConnectorInfoTextListProps = {
+  name: string;
+  id: string;
+  type?: string;
+  bootstrapServer: string;
+  kafkaId: string;
+  owner: string;
+  namespaceId: string;
+  createdAt: Date;
+  modifiedAt: Date;
+  error?: string;
+};
+
+export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps> =
+  ({
+    name,
+    id,
+    type,
+    bootstrapServer,
+    kafkaId,
+    owner,
+    namespaceId,
+    createdAt,
+    modifiedAt,
+    error,
+  }) => {
+    const { t } = useTranslation();
+    const textListItem = (title: string, value?: ReactNode) => (
+      <>
+        {value && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              {title}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {value}
+            </TextListItem>
+          </>
+        )}
+      </>
+    );
+    return (
+      <TextContent>
+        <TextList component={TextListVariants.dl}>
+          {textListItem('Connector', name)}
+          {textListItem('Connector Id', id)}
+          {textListItem('Connector type', type)}
+          {textListItem('Bootstrap server', bootstrapServer)}
+          {textListItem('Kafka_instance', kafkaId)}
+          {textListItem('Deployment namespace', namespaceId)}
+          {textListItem('Owner', owner)}
+          {textListItem(
+            'Time created',
+            <time
+              title={t('{{date}}', { date: createdAt })}
+              dateTime={createdAt.toISOString()}
+            >
+              {t('{{ date, ago }}', { date: createdAt })}
+            </time>
+          )}
+          {textListItem(
+            'Time updated',
+            <time
+              title={t('{{date}}', { date: modifiedAt })}
+              dateTime={modifiedAt.toISOString()}
+            >
+              {t('{{ date, ago }}', { date: modifiedAt })}
+            </time>
+          )}
+          {textListItem('Failure Reason', error)}
+        </TextList>
+      </TextContent>
+    );
+  };

--- a/src/app/pages/ConnectorDetailsPage/OverviewPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/OverviewPage.tsx
@@ -1,14 +1,7 @@
-import React, { FC, ReactNode } from 'react';
+import { ConnectorInfoTextList } from '@app/components/ConnectorInfoTextList/ConnectorInfoTextList';
+import React, { FC } from 'react';
 
-import {
-  PageSection,
-  PageSectionVariants,
-  TextContent,
-  TextList,
-  TextListItem,
-  TextListItemVariants,
-  TextListVariants,
-} from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import { Connector } from '@rhoas/connector-management-sdk';
 
@@ -16,32 +9,21 @@ export interface OverviewPageProps {
   connectorData: Connector;
 }
 
-const textListItem = (title: string, value?: ReactNode) => (
-  <>
-    {value && (
-      <>
-        <TextListItem component={TextListItemVariants.dt}>{title}</TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>{value}</TextListItem>
-      </>
-    )}
-  </>
-);
-
 export const OverviewPage: FC<OverviewPageProps> = ({ connectorData }) => {
   return (
     <PageSection variant={PageSectionVariants.light}>
-      <TextContent>
-        <TextList component={TextListVariants.dl}>
-          {textListItem('Connector id', connectorData?.id!)}
-          {textListItem('Connector type', connectorData?.connector_type_id)}
-          {textListItem('Kafka_instance', connectorData?.kafka?.id)}
-          {textListItem('Bootstrap server', connectorData?.kafka?.url)}
-          {textListItem('Deployment namespace', connectorData?.namespace_id)}
-          {textListItem('Owner', connectorData?.owner)}
-          {textListItem('Time created', connectorData?.created_at)}
-          {textListItem('Time updated', connectorData?.modified_at)}
-        </TextList>
-      </TextContent>
+      <ConnectorInfoTextList
+        name={connectorData?.name}
+        id={connectorData?.id!}
+        type={connectorData?.connector_type_id}
+        bootstrapServer={connectorData?.kafka?.url}
+        kafkaId={connectorData?.kafka?.id}
+        namespaceId={connectorData?.namespace_id!}
+        owner={connectorData?.owner!}
+        createdAt={new Date(connectorData?.created_at!)}
+        modifiedAt={new Date(connectorData?.modified_at!)}
+        error={connectorData?.status?.error}
+      />
     </PageSection>
   );
 };


### PR DESCRIPTION
This adds a "Failure Reason" field to the connector detail panel and
overview page.  This also refactors the overview page and panel to use
the same shared component so that the connector details are shown
consistently across views.

No connectors are failed on staging at the moment, but here's a comparison of the drawer and overview now with this change:

![image](https://user-images.githubusercontent.com/351660/162037663-9c0fd8b2-c784-4367-9184-e907e88ca424.png)

and

![image](https://user-images.githubusercontent.com/351660/162037805-77a3aaca-fec6-4e08-a2aa-99c56e8a51a3.png)
