### PR TITLE
chore: fix cancel duplicate connector description key typo

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -77,7 +77,7 @@
   "kafkaStepDescription": "The selected Kafka instance works with your Connectors instance. A source connector ingests data from another system into a Kafka instance. A sink connector propagates data from a Kafka instance into another system.",
   "leave": "Leave",
   "leaveCreateConnectorConfirmModalDescription": "Changes you have made will be lost and no connector will be created.",
-  "leaveDuplicateConfirmModalDescription": "Changes you have made will be lost and no connector will be created.",
+  "leaveDuplicateConnectorConfirmModalDescription": "Changes you have made will be lost and no connector will be created.",
   "leaveEditConfirmModalDescription": "Changes you have made to the connector properties will not be saved.",
   "leaveEditConfirmModalTitle": "Leave page?",
   "loading": "Loading",


### PR DESCRIPTION
This fixes a typo for the i18n key that contains the modal description
for cancelling the duplicate connector flow.

![image](https://user-images.githubusercontent.com/351660/162739808-dc2476cd-8fe2-4aeb-9ebb-c47221d92e75.png)

![image](https://user-images.githubusercontent.com/351660/162740031-0e7de26c-2ba9-48e9-bcb8-4bedc9428571.png)

