### PR TITLE
MGDCTRS-741 fix: pass through the status values

### DIFF
--- a/src/app/components/ConnectorDrawer/ConnectorDrawer.stories.tsx
+++ b/src/app/components/ConnectorDrawer/ConnectorDrawer.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { Drawer, DrawerContent } from '@patternfly/react-core';
 
-import { ConnectorStatuses } from '../ConnectorStatus/ConnectorStatus';
+import { ConnectorStatusValues } from '../ConnectorStatus/ConnectorStatus.stories';
 import { ConnectorDrawerPanelContent } from './ConnectorDrawer';
 
 export default {
@@ -29,7 +29,7 @@ export default {
   },
   argTypes: {
     status: {
-      options: Object.values(ConnectorStatuses),
+      options: Object.values(ConnectorStatusValues),
       control: 'radio',
     },
   },

--- a/src/app/components/ConnectorStatus/ConnectorStatus.css
+++ b/src/app/components/ConnectorStatus/ConnectorStatus.css
@@ -1,7 +1,0 @@
-.cos--connectors__table--icon--completed {
-  color: var(--pf-global--success-color--100);
-}
-
-.cos--connectors__table--icon--failed {
-  color: var(--pf-global--danger-color--100);
-}

--- a/src/app/components/ConnectorStatus/ConnectorStatus.stories.tsx
+++ b/src/app/components/ConnectorStatus/ConnectorStatus.stories.tsx
@@ -1,22 +1,43 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import React from 'react';
 
-import { ConnectorStatus, ConnectorStatuses } from './ConnectorStatus';
+import {
+  List,
+  ListComponent,
+  ListItem,
+  OrderType,
+} from '@patternfly/react-core';
+
+import { ConnectorStatus } from './ConnectorStatus';
+
+// These values are copied over from the backend code
+export enum ConnectorStatusValues {
+  ConnectorStatusPhaseAssigning = 'assigning', // set by kas-fleet-manager - user request
+  ConnectorStatusPhaseAssigned = 'assigned', // set by kas-fleet-manager - worker
+  ConnectorStatusPhaseUpdating = 'updating', // set by kas-fleet-manager - user request
+  ConnectorStatusPhaseStopped = 'stopped', // set by kas-fleet-manager - user request
+  ConnectorStatusPhaseProvisioning = 'provisioning', // set by kas-agent
+  ConnectorStatusPhaseReady = 'ready', // set by the agent
+  ConnectorStatusPhaseFailed = 'failed', // set by the agent
+  ConnectorStatusPhaseDeprovisioning = 'deprovisioning', // set by kas-agent
+  ConnectorStatusPhaseDeleting = 'deleting', // set by the kas-fleet-manager - user request
+  ConnectorStatusPhaseDeleted = 'deleted', // set by the agent
+}
 
 export default {
   title: 'UI/Connector/Statuses',
   component: ConnectorStatus,
-  args: {
-    name: 'Sample name',
-  },
+  excludeStories: /ConnectorStatusValues/,
 } as ComponentMeta<typeof ConnectorStatus>;
 
 const Template: ComponentStory<typeof ConnectorStatus> = (args) => (
-  <div>
-    {Object.values(ConnectorStatuses).map((s, idx) => (
-      <ConnectorStatus key={idx} {...args} status={s} />
+  <List component={ListComponent.ol} type={OrderType.number}>
+    {Object.values(ConnectorStatusValues).map((s, idx) => (
+      <ListItem>
+        <ConnectorStatus key={idx} {...args} status={s} />
+      </ListItem>
     ))}
-  </div>
+  </List>
 );
 
 export const Statuses = Template.bind({});

--- a/src/app/components/ConnectorStatus/ConnectorStatus.tsx
+++ b/src/app/components/ConnectorStatus/ConnectorStatus.tsx
@@ -1,14 +1,14 @@
+import { capitalize } from 'lodash';
 import React, { FunctionComponent } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
-  PendingIcon,
+  OutlinedPauseCircleIcon,
+  OutlinedTimesCircleIcon,
 } from '@patternfly/react-icons';
-
-import './ConnectorStatus.css';
+import * as tokens from '@patternfly/react-tokens';
 
 type ConnectorStatusProps = {
   name: string;
@@ -20,7 +20,6 @@ export const ConnectorStatus: FunctionComponent<ConnectorStatusProps> = ({
   status,
 }) => {
   const label = useConnectorStatusLabel(status);
-
   return (
     <Flex>
       <FlexItem spacer={{ default: 'spacerSm' }}>
@@ -37,58 +36,26 @@ export const ConnectorStatusIcon: FunctionComponent<ConnectorStatusProps> = ({
 }) => {
   switch (status?.toLowerCase()) {
     case 'ready':
-      return (
-        <CheckCircleIcon className="cos--connectors__table--icon--completed" />
-      );
+      return <CheckCircleIcon color={tokens.global_success_color_100.value} />;
     case 'failed':
       return (
-        <ExclamationCircleIcon className="cos--connectors__table--icon--failed" />
+        <ExclamationCircleIcon color={tokens.global_danger_color_100.value} />
       );
-    case 'accepted':
-      return <PendingIcon />;
-    case 'provisioning':
-    case 'preparing':
-    case 'disconnected':
+    case 'stopped':
+      return <OutlinedPauseCircleIcon />;
+    case 'deleted':
+      return <OutlinedTimesCircleIcon />;
+    default:
       return (
         <Spinner
           size="md"
           aria-label={name}
-          aria-valuetext="Creation in progress"
+          aria-valuetext="Please wait, tasks are in progress"
         />
       );
-    case 'deprovision':
-    case 'deleted':
-      return null;
   }
-  return <PendingIcon />;
 };
 
-export enum ConnectorStatuses {
-  Ready = 'ready',
-  Failed = 'failed',
-  Assigning = 'assigning',
-  Assigned = 'assigned',
-  Updating = 'updating',
-  Provisioning = 'provisioning',
-  Deleting = 'deleting',
-  Deleted = 'deleted',
-  Disconnected = 'disconnected',
-}
-
 export function useConnectorStatusLabel(status: string) {
-  const { t } = useTranslation();
-
-  const statusOptions = [
-    { value: ConnectorStatuses.Ready, label: t('running') },
-    { value: ConnectorStatuses.Failed, label: t('failed') },
-    { value: ConnectorStatuses.Assigning, label: t('creationPending') },
-    { value: ConnectorStatuses.Assigned, label: t('creationInProgress') },
-    { value: ConnectorStatuses.Updating, label: t('creationInProgress') },
-    { value: ConnectorStatuses.Provisioning, label: t('creationInProgress') },
-    { value: ConnectorStatuses.Deleting, label: t('deleting') },
-    { value: ConnectorStatuses.Deleted, label: t('deleted') },
-    { value: ConnectorStatuses.Disconnected, label: t('provisioning') },
-  ];
-
-  return statusOptions.find((s) => s.value === status)?.label || status;
+  return typeof status !== undefined ? capitalize(status) : 'Undefined';
 }


### PR DESCRIPTION
This change removes the mapping on the UI side for all of the connector
status values and instead just titlizes the current value.  The icon
mapping is simplified as well to reflect that several of these status
values represent a transitional state.

So with all of the current backend values we have:

![image](https://user-images.githubusercontent.com/351660/163011405-eb4e7cf0-3e48-4aae-b391-cae9a5853c8a.png)

and

![image](https://user-images.githubusercontent.com/351660/163011494-58657598-b613-422f-9778-b3eb6118d6de.png)
