### PR TITLE
chore: add more items per page options

### DIFF
--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -29,6 +29,14 @@ export const Pagination: FunctionComponent<PaginationProps> = ({
       title: '10',
       value: 10,
     },
+    {
+      title: '20',
+      value: 20,
+    },
+    {
+      title: '50',
+      value: 50,
+    },
   ];
   return (
     <PFPagination


### PR DESCRIPTION
This adds 20 and 50 items per page options to the pagination control on
all views.

![image](https://user-images.githubusercontent.com/351660/163187800-5deccf07-dc9b-4293-8281-437e2588c7a5.png)
