### PR TITLE
MGDCTRS-830: fix: correct schema assumptions

### DIFF
--- a/src/app/pages/ConnectorDetailsPage/ConfigurationStep.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationStep.tsx
@@ -48,10 +48,14 @@ export const ConfigurationStep: FC<ConfigurationStepProps> = ({
 
   const getFieldViewComponent = (
     propertyKey: string,
-    propertyDefinition: { title?: string; type?: string; 'x-group'?: string },
+    propertyDefinition: {
+      title?: string;
+      type?: string;
+      oneOf?: Array<{ format: string }>;
+    },
     value: any
   ): React.ReactNode => {
-    const { title, type, 'x-group': xGroup } = propertyDefinition;
+    const { title, type, oneOf } = propertyDefinition;
     // a good place to start troubleshooting problems in the detail view
     /*
     console.log(
@@ -88,9 +92,12 @@ export const ConfigurationStep: FC<ConfigurationStepProps> = ({
         }
         return noPropertySet(title || propertyNameFallback);
       default:
-        switch (xGroup) {
-          case 'credentials':
+        if (typeof oneOf !== 'undefined') {
+          // we are assuming the schema is consistent here
+          const [def] = oneOf;
+          if (def.format === 'password') {
             return <Text>**************************</Text>;
+          }
         }
         if (typeof value !== 'undefined') {
           return <Text>{value}</Text>;


### PR DESCRIPTION
This fixes the elastic search sink connector form by correcting the way
the x-group field was interpreted, now the code properly evaluates just
the oneOf field.

So instead of:

![image](https://user-images.githubusercontent.com/351660/164265342-ca2fc067-f607-43a9-a954-0f8d4f3482cd.png)

we get:

![image](https://user-images.githubusercontent.com/351660/164265569-00cbd031-85ae-423e-bf7f-b3b7c38047e5.png)

and so on.  This also updates the detail view code to follow the same assumption.
