### PR TITLE
MGDCTRS-699 chore: slight updates to empty states

### DIFF
--- a/src/app/components/EmptyStateNoKafkaInstances/EmptyStateNoKafkaInstances.tsx
+++ b/src/app/components/EmptyStateNoKafkaInstances/EmptyStateNoKafkaInstances.tsx
@@ -26,7 +26,7 @@ export const EmptyStateNoKafkaInstances: FunctionComponent<EmptyStateNoKafkaInst
         className={css('pf-u-pt-2xl pf-u-pt-3xl-on-md')}
       >
         <EmptyStateIcon icon={PlusCircleIcon} />
-        <Title headingLevel={'h1'} size={TitleSizes['4xl']}>
+        <Title headingLevel={'h1'} size={TitleSizes['xl']}>
           {t('noKafkaInstanceAvailable')}
         </Title>
         <EmptyStateBody>{t('noKafkaInstanceAvailableBody')}</EmptyStateBody>

--- a/src/app/components/EmptyStateNoNamespace/EmptyStateNoNamespace.stories.tsx
+++ b/src/app/components/EmptyStateNoNamespace/EmptyStateNoNamespace.stories.tsx
@@ -14,4 +14,4 @@ const Template: ComponentStory<typeof EmptyStateNoNamespace> = (args) => (
   <EmptyStateNoNamespace {...args} />
 );
 
-export const NoOSDCluster = Template.bind({});
+export const NoNamespace = Template.bind({});

--- a/src/app/components/EmptyStateNoNamespace/EmptyStateNoNamespace.tsx
+++ b/src/app/components/EmptyStateNoNamespace/EmptyStateNoNamespace.tsx
@@ -10,6 +10,7 @@ import {
   EmptyStateSecondaryActions,
   EmptyStateVariant,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import {
   ExternalLinkSquareAltIcon,
@@ -27,7 +28,7 @@ export const EmptyStateNoNamespace: FunctionComponent<EmptyStateNoNamespaceProps
       <Bullseye>
         <EmptyState variant={EmptyStateVariant.large}>
           <EmptyStateIcon icon={PlusCircleIcon} />
-          <Title headingLevel="h4" size="lg">
+          <Title headingLevel={'h1'} size={TitleSizes['xl']}>
             {t('noNamespaceAvailable')}
           </Title>
           <EmptyStateBody>{t('namespaceEmptyMsg')}</EmptyStateBody>


### PR DESCRIPTION
This change updates the empty state titles slightly for consistency and
also fixes the storybook tree.

![image](https://user-images.githubusercontent.com/351660/164289880-f280f8fe-9551-4742-8042-aa8a3fead5ed.png)

![image](https://user-images.githubusercontent.com/351660/164289956-d40c10b9-1f94-49dc-95bf-450428a08138.png)
