### PR TITLE
MGDCTRS-893 fix: switch to the Link component

### DIFF
--- a/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
@@ -5,7 +5,7 @@ import { CONNECTOR_DETAILS_TABS } from '@constants/constants';
 import { useCos } from '@context/CosContext';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 
 import {
   PageSection,
@@ -21,7 +21,7 @@ import {
   AlertVariant,
 } from '@patternfly/react-core';
 
-import { useAlert, useBasename } from '@rhoas/app-services-ui-shared';
+import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Connector, ConnectorType } from '@rhoas/connector-management-sdk';
 
 import { ConfigurationPage } from './ConfigurationPage';
@@ -182,7 +182,6 @@ export const ConnectorDetailsHeader: FC<ConnectorDetailsHeaderProps> = ({
   connectorData,
 }) => {
   const { t } = useTranslation();
-  const basename = useBasename();
 
   // const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -220,8 +219,8 @@ export const ConnectorDetailsHeader: FC<ConnectorDetailsHeaderProps> = ({
   return (
     <PageSection variant={'light'} hasShadowBottom>
       <Breadcrumb>
-        <BreadcrumbItem to={basename?.getBasename()}>
-          {t('connectorsInstances')}
+        <BreadcrumbItem>
+          <Link to={'/'}>{t('connectorsInstances')}</Link>
         </BreadcrumbItem>
         <BreadcrumbItem isActive>{connectorData?.name}</BreadcrumbItem>
       </Breadcrumb>

--- a/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
+++ b/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
@@ -4,6 +4,7 @@ import { useCos } from '@context/CosContext';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import React, { FunctionComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 import {
   Breadcrumb,
@@ -15,7 +16,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-import { useBasename, useConfig } from '@rhoas/app-services-ui-shared';
+import { useConfig } from '@rhoas/app-services-ui-shared';
 
 type CreateConnectorPageProps = {
   onSave: (name: string) => void;
@@ -25,7 +26,6 @@ export const CreateConnectorPage: FunctionComponent<CreateConnectorPageProps> =
   ({ onSave, onClose }) => {
     const { t } = useTranslation();
     const config = useConfig();
-    const basename = useBasename();
     const { connectorsApiBasePath, getToken } = useCos();
     const [askForLeaveConfirm, setAskForLeaveConfirm] = useState(false);
     const openLeaveConfirm = () => setAskForLeaveConfirm(true);
@@ -34,8 +34,8 @@ export const CreateConnectorPage: FunctionComponent<CreateConnectorPageProps> =
       <>
         <PageSection variant={'light'} hasShadowBottom>
           <Breadcrumb>
-            <BreadcrumbItem to={basename?.getBasename()}>
-              {t('connectorsInstances')}
+            <BreadcrumbItem>
+              <Link to={'/'}>{t('connectorsInstances')}</Link>
             </BreadcrumbItem>
             <BreadcrumbItem isActive>
               {t('createAConnectorsInstance')}

--- a/src/app/pages/CreateConnectorPage/DuplicateConnectorPage.tsx
+++ b/src/app/pages/CreateConnectorPage/DuplicateConnectorPage.tsx
@@ -12,7 +12,7 @@ import React, {
   useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import {
   Breadcrumb,
@@ -28,7 +28,6 @@ import {
 import {
   AlertVariant,
   useAlert,
-  useBasename,
   useConfig,
 } from '@rhoas/app-services-ui-shared';
 import { Connector, ConnectorTypeAllOf } from '@rhoas/connector-management-sdk';
@@ -42,7 +41,6 @@ export const DuplicateConnectorPage: FunctionComponent<DuplicateConnectorPagePro
     const { t } = useTranslation();
     const alert = useAlert();
     const config = useConfig();
-    const basename = useBasename();
     const { connectorsApiBasePath, getToken } = useCos();
     const [askForLeaveConfirm, setAskForLeaveConfirm] = useState(false);
     const openLeaveConfirm = () => setAskForLeaveConfirm(true);
@@ -98,8 +96,8 @@ export const DuplicateConnectorPage: FunctionComponent<DuplicateConnectorPagePro
       <>
         <PageSection variant={'light'} hasShadowBottom>
           <Breadcrumb>
-            <BreadcrumbItem to={basename?.getBasename()}>
-              {t('connectorsInstances')}
+            <BreadcrumbItem>
+              <Link to={'/'}>{t('connectorsInstances')}</Link>
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{t('duplicateConnector')}</BreadcrumbItem>
           </Breadcrumb>


### PR DESCRIPTION
It turns out the BreadcrumbItem component uses a raw anchor tag which
bypasses React's router, causing a full page reload.

Fixes https://issues.redhat.com/browse/MGDCTRS-893