### PR TITLE
MGDCTRS-892: chore: Update the configurator prop

### DIFF
--- a/src/app/machines/StepConfiguratorLoader.machine.ts
+++ b/src/app/machines/StepConfiguratorLoader.machine.ts
@@ -6,10 +6,17 @@ import { createModel } from 'xstate/lib/model';
 
 import { ConnectorType } from '@rhoas/connector-management-sdk';
 
+export enum ConfigurationMode {
+  CREATE = 'create',
+  VIEW = 'view',
+  EDIT = 'edit',
+  DUPLICATE = 'duplicate',
+}
+
 export type ConnectorConfiguratorProps = {
   activeStep?: number;
   connector: ConnectorType;
-  isViewMode?: boolean;
+  uiPath: ConfigurationMode;
   configuration?: unknown;
   onChange: (configuration: Map<string, unknown>, isValid: boolean) => void;
   duplicateMode?: boolean | undefined;

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationPage.tsx
@@ -1,7 +1,7 @@
 import { updateConnector } from '@apis/api';
 import { Loading } from '@app/components/Loading/Loading';
 import { StepErrorBoundary } from '@app/components/StepErrorBoundary/StepErrorBoundary';
-import { ConnectorConfiguratorComponent } from '@app/machines/StepConfiguratorLoader.machine';
+import { ConfigurationMode, ConnectorConfiguratorComponent } from '@app/machines/StepConfiguratorLoader.machine';
 import { useCos } from '@context/CosContext';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import { clearEmptyObjectValues, mapToObject } from '@utils/shared';
@@ -416,7 +416,7 @@ const ConnectedCustomConfigurator: FC<{
     <Configurator
       activeStep={step - 1}
       connector={connector}
-      isViewMode={!isEditMode}
+      uiPath={isEditMode ? ConfigurationMode.EDIT : ConfigurationMode.VIEW}
       configuration={
         formConfiguration instanceof Map
           ? formConfiguration

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationPage.tsx
@@ -1,7 +1,10 @@
 import { updateConnector } from '@apis/api';
 import { Loading } from '@app/components/Loading/Loading';
 import { StepErrorBoundary } from '@app/components/StepErrorBoundary/StepErrorBoundary';
-import { ConfigurationMode, ConnectorConfiguratorComponent } from '@app/machines/StepConfiguratorLoader.machine';
+import {
+  ConfigurationMode,
+  ConnectorConfiguratorComponent,
+} from '@app/machines/StepConfiguratorLoader.machine';
 import { useCos } from '@context/CosContext';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import { clearEmptyObjectValues, mapToObject } from '@utils/shared';

--- a/src/app/pages/CreateConnectorPage/StepCommon.tsx
+++ b/src/app/pages/CreateConnectorPage/StepCommon.tsx
@@ -25,6 +25,7 @@ export const StepCommon: FC = () => {
     onSetSaCreated,
     onSetName,
     onSetServiceAccount,
+    duplicateMode,
   } = useBasicMachine();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -93,6 +94,7 @@ export const StepCommon: FC = () => {
                   isRequired
                   fieldId="clientSecret"
                   className="pf-u-mb-0"
+                  helperText={duplicateMode ? t('credentialDuplicateFieldHelpText') : ''}
                 >
                   <TextInput
                     value={serviceAccount.clientSecret}

--- a/src/app/pages/CreateConnectorPage/StepCommon.tsx
+++ b/src/app/pages/CreateConnectorPage/StepCommon.tsx
@@ -94,7 +94,9 @@ export const StepCommon: FC = () => {
                   isRequired
                   fieldId="clientSecret"
                   className="pf-u-mb-0"
-                  helperText={duplicateMode ? t('credentialDuplicateFieldHelpText') : ''}
+                  helperText={
+                    duplicateMode ? t('credentialDuplicateFieldHelpText') : ''
+                  }
                 >
                   <TextInput
                     value={serviceAccount.clientSecret}

--- a/src/app/pages/CreateConnectorPage/StepConfigurator.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConfigurator.tsx
@@ -3,6 +3,7 @@ import { JsonSchemaConfigurator } from '@app/components/JsonSchemaConfigurator/J
 import { StepBodyLayout } from '@app/components/StepBodyLayout/StepBodyLayout';
 import { ConfiguratorActorRef } from '@app/machines/StepConfigurator.machine';
 import {
+  ConfigurationMode,
   ConnectorConfiguratorComponent,
   ConnectorConfiguratorProps,
 } from '@app/machines/StepConfiguratorLoader.machine';
@@ -65,7 +66,7 @@ const ConnectedCustomConfigurator: FunctionComponent<{
       activeStep={activeStep}
       configuration={configuration}
       connector={connector}
-      isViewMode={duplicateMode && false}
+      uiPath={duplicateMode ? ConfigurationMode.DUPLICATE : ConfigurationMode.CREATE}
       onChange={(configuration, isValid) => {
         actor.send({ type: 'change', configuration, isValid });
       }}

--- a/src/app/pages/CreateConnectorPage/StepConfigurator.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConfigurator.tsx
@@ -66,7 +66,9 @@ const ConnectedCustomConfigurator: FunctionComponent<{
       activeStep={activeStep}
       configuration={configuration}
       connector={connector}
-      uiPath={duplicateMode ? ConfigurationMode.DUPLICATE : ConfigurationMode.CREATE}
+      uiPath={
+        duplicateMode ? ConfigurationMode.DUPLICATE : ConfigurationMode.CREATE
+      }
       onChange={(configuration, isValid) => {
         actor.send({ type: 'change', configuration, isValid });
       }}


### PR DESCRIPTION
- Update the external UI configurator prop, from earlier `isViewMode` to `uiPath` to differenciate between edit and duplicate flow. Until now `isViewMode` was used to differentiate between create (`undefined`), edit/duplicate(`false`) and view(`true`)
- Add helper text to "Client secret " in duplicate flow.
screenshot 
![image](https://user-images.githubusercontent.com/8264372/171805930-9aa2e845-2eba-454a-80c4-fbd6358c4172.png)
