### PR TITLE
MGDCTRS-1044 fix: ensure unset enums show as unset

### DIFF
--- a/cypress/fixtures/connectors/aws_kinesis_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_kinesis_sink_0.1.json
@@ -1,139 +1,204 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS Kinesis Sink",
-          "required" : [ "stream", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "stream" : {
-              "title" : "Stream Name",
-              "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
-              "type" : "string"
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_kinesis_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS Kinesis Sink",
-    "description" : "AWS Kinesis Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-kinesis-sink-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-kinesis-sink",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-kinesis-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon Kinesis sink",
+    "icon_href" : "TODO",
+    "id" : "aws_kinesis_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "Amazon Kinesis sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_stream", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_stream" : {
+          "title" : "Stream Name",
+          "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
+          "type" : "string"
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            },
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          },
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
+++ b/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
@@ -1,139 +1,209 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS Kinesis Source",
-          "required" : [ "stream", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "stream" : {
-              "title" : "Stream Name",
-              "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
-              "type" : "string"
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_kinesis_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS Kinesis Source",
-    "description" : "AWS Kinesis Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-kinesis:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-kinesis-source-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "cos-aws-kinesis-source",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-kinesis-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon Kinesis source",
+    "icon_href" : "TODO",
+    "id" : "aws_kinesis_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "Amazon Kinesis source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_stream", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_stream" : {
+          "title" : "Stream Name",
+          "description" : "The Kinesis stream that you want to access (needs to be created in advance)",
+          "type" : "string"
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1"
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_delay" : {
+          "title" : "Delay",
+          "description" : "Milliseconds before the next poll of the selected stream",
+          "type" : "integer",
+          "default" : 500
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            },
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          },
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_s3_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_s3_sink_0.1.json
@@ -1,145 +1,200 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS S3 Sink",
-          "required" : [ "bucketNameOrArn", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "bucketNameOrArn" : {
-              "title" : "Bucket Name",
-              "description" : "The S3 Bucket name or ARN.",
-              "type" : "string"
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS.",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS.",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to.",
-              "type" : "string",
-              "example" : "eu-west-1"
-            },
-            "autoCreateBucket" : {
-              "title" : "Autocreate Bucket",
-              "description" : "Setting the autocreation of the S3 bucket bucketName.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_s3_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS S3 Sink",
-    "description" : "AWS S3 Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-s3-sink-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-s3-sink",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-s3-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon S3 sink",
+    "icon_href" : "TODO",
+    "id" : "aws_s3_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "Amazon S3 sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_bucket_name_or_arn", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_bucket_name_or_arn" : {
+          "title" : "Bucket Name",
+          "description" : "The S3 Bucket name or ARN.",
+          "type" : "string"
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS.",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS.",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to.",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_auto_create_bucket" : {
+          "title" : "Autocreate Bucket",
+          "description" : "Setting the autocreation of the S3 bucket bucketName.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_key_name" : {
+          "title" : "Key Name",
+          "description" : "The key name for saving an element in the bucket.",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_s3_source_0.1.json
+++ b/cypress/fixtures/connectors/aws_s3_source_0.1.json
@@ -1,169 +1,225 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS S3 Source",
-          "required" : [ "bucketNameOrArn", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "bucketNameOrArn" : {
-              "title" : "Bucket Name",
-              "description" : "The S3 Bucket name or ARN",
-              "type" : "string"
-            },
-            "deleteAfterRead" : {
-              "title" : "Auto-delete Objects",
-              "description" : "Delete objects after consuming them",
-              "type" : "boolean",
-              "default" : true
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            },
-            "autoCreateBucket" : {
-              "title" : "Autocreate Bucket",
-              "description" : "Setting the autocreation of the S3 bucket bucketName.",
-              "type" : "boolean",
-              "default" : false
-            },
-            "includeBody" : {
-              "title" : "Include Body",
-              "description" : "If it is true, the exchange will be consumed and put into the body and closed. If false the S3Object stream will be put raw into the body and the headers will be set with the S3 object metadata.",
-              "type" : "boolean",
-              "default" : true
-            },
-            "prefix" : {
-              "title" : "Prefix",
-              "description" : "The AWS S3 bucket prefix to consider while searching",
-              "type" : "string",
-              "example" : "folder/"
-            },
-            "ignoreBody" : {
-              "title" : "Ignore Body",
-              "description" : "If it is true, the S3 Object Body will be ignored completely, if it is set to false the S3 Object will be put in the body. Setting this to true, will override any behavior defined by includeBody option.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_s3_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS S3 Source",
-    "description" : "AWS S3 Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-s3:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-s3-source-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-s3-source",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-s3-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon S3 source",
+    "icon_href" : "TODO",
+    "id" : "aws_s3_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "Amazon S3 source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_bucket_name_or_arn", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_bucket_name_or_arn" : {
+          "title" : "Bucket Name",
+          "description" : "The S3 Bucket name or ARN",
+          "type" : "string"
+        },
+        "aws_delete_after_read" : {
+          "title" : "Auto-delete Objects",
+          "description" : "Delete objects after consuming them",
+          "type" : "boolean",
+          "default" : true
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_auto_create_bucket" : {
+          "title" : "Autocreate Bucket",
+          "description" : "Setting the autocreation of the S3 bucket bucketName.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_include_body" : {
+          "title" : "Include Body",
+          "description" : "If it is true, the exchange will be consumed and put into the body and closed. If false the S3Object stream will be put raw into the body and the headers will be set with the S3 object metadata.",
+          "type" : "boolean",
+          "default" : true
+        },
+        "aws_prefix" : {
+          "title" : "Prefix",
+          "description" : "The AWS S3 bucket prefix to consider while searching",
+          "type" : "string",
+          "example" : "folder/"
+        },
+        "aws_ignore_body" : {
+          "title" : "Ignore Body",
+          "description" : "If it is true, the S3 Object Body will be ignored completely, if it is set to false the S3 Object will be put in the body. Setting this to true, will override any behavior defined by includeBody option.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_delay" : {
+          "title" : "Delay",
+          "description" : "Milliseconds before the next poll of the selected bucket",
+          "type" : "integer",
+          "default" : 500
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_sns_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_sns_sink_0.1.json
@@ -1,145 +1,195 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS SNS Sink",
-          "required" : [ "topicNameOrArn", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "topicNameOrArn" : {
-              "title" : "Topic Name",
-              "description" : "The SQS Topic name or ARN",
-              "type" : "string"
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            },
-            "autoCreateTopic" : {
-              "title" : "Autocreate Topic",
-              "description" : "Setting the autocreation of the SNS topic.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_sns_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS SNS Sink",
-    "description" : "AWS SNS Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sns:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-sns-sink-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-sns-sink",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-sns-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon Simple Notification Service sink",
+    "icon_href" : "TODO",
+    "id" : "aws_sns_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "Amazon Simple Notification Service sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_topic_name_or_arn", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_topic_name_or_arn" : {
+          "title" : "Topic Name",
+          "description" : "The SQS Topic name or ARN",
+          "type" : "string"
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_auto_create_topic" : {
+          "title" : "Autocreate Topic",
+          "description" : "Setting the autocreation of the SNS topic.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_sqs_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_sqs_sink_0.1.json
@@ -1,145 +1,208 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS SQS Sink",
-          "required" : [ "queueNameOrArn", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "queueNameOrArn" : {
-              "title" : "Queue Name",
-              "description" : "The SQS Queue name or ARN",
-              "type" : "string"
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            },
-            "autoCreateQueue" : {
-              "title" : "Autocreate Queue",
-              "description" : "Setting the autocreation of the SQS queue.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_sqs_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS SQS Sink",
-    "description" : "AWS SQS Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-sqs-sink-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-sqs-sink",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-sqs-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon Simple Queue Service sink",
+    "icon_href" : "TODO",
+    "id" : "aws_sqs_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "Amazon Simple Queue Service sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_queue_name_or_arn", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_queue_name_or_arn" : {
+          "title" : "Queue Name",
+          "description" : "The SQS Queue name or ARN",
+          "type" : "string"
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_auto_create_queue" : {
+          "title" : "Autocreate Queue",
+          "description" : "Setting the autocreation of the SQS queue.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_amazon_a_w_s_host" : {
+          "title" : "AWS Host",
+          "description" : "The hostname of the Amazon AWS cloud.",
+          "type" : "string",
+          "default" : "amazonaws.com"
+        },
+        "aws_protocol" : {
+          "title" : "Protocol",
+          "description" : "The underlying protocol used to communicate with SQS",
+          "type" : "string",
+          "example" : "http or https",
+          "default" : "https"
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/aws_sqs_source_0.1.json
+++ b/cypress/fixtures/connectors/aws_sqs_source_0.1.json
@@ -1,151 +1,225 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "AWS SQS Source",
-          "required" : [ "queueNameOrArn", "accessKey", "secretKey", "region" ],
-          "properties" : {
-            "queueNameOrArn" : {
-              "title" : "Queue Name",
-              "description" : "The SQS Queue Name or ARN",
-              "type" : "string"
-            },
-            "deleteAfterRead" : {
-              "title" : "Auto-delete Messages",
-              "description" : "Delete messages after consuming them",
-              "type" : "boolean",
-              "default" : true
-            },
-            "accessKey" : {
-              "title" : "Access Key",
-              "oneOf" : [ {
-                "title" : "Access Key",
-                "description" : "The access key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the accessKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "secretKey" : {
-              "title" : "Secret Key",
-              "oneOf" : [ {
-                "title" : "Secret Key",
-                "description" : "The secret key obtained from AWS",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the secretKey",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "region" : {
-              "title" : "AWS Region",
-              "description" : "The AWS region to connect to",
-              "type" : "string",
-              "example" : "eu-west-1"
-            },
-            "autoCreateQueue" : {
-              "title" : "Autocreate Queue",
-              "description" : "Setting the autocreation of the SQS queue.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "aws_sqs_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "AWS SQS Source",
-    "description" : "AWS SQS Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-aws-sqs:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-aws-sqs-source-0.1",
+        "consumes" : "application/octet-stream",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "aws-sqs-source",
+            "prefix" : "aws"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "aws-sqs-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/octet-stream"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "Amazon Simple Queue Service source",
+    "icon_href" : "TODO",
+    "id" : "aws_sqs_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "Amazon Simple Queue Service source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "aws_queue_name_or_arn", "aws_region", "kafka_topic", "aws_access_key", "aws_secret_key" ],
+      "properties" : {
+        "aws_queue_name_or_arn" : {
+          "title" : "Queue Name",
+          "description" : "The SQS Queue Name or ARN",
+          "type" : "string"
+        },
+        "aws_delete_after_read" : {
+          "title" : "Auto-delete Messages",
+          "description" : "Delete messages after consuming them",
+          "type" : "boolean",
+          "default" : true
+        },
+        "aws_access_key" : {
+          "title" : "Access Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Access Key",
+            "description" : "The access key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_access_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_secret_key" : {
+          "title" : "Secret Key",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Secret Key",
+            "description" : "The secret key obtained from AWS",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the aws_secret_key",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "aws_region" : {
+          "title" : "AWS Region",
+          "description" : "The AWS region to connect to",
+          "type" : "string",
+          "example" : "eu-west-1",
+          "enum" : [ "af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "fips-us-east-1", "fips-us-east-2", "fips-us-west-1", "fips-us-west-2", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1" ]
+        },
+        "aws_auto_create_queue" : {
+          "title" : "Autocreate Queue",
+          "description" : "Setting the autocreation of the SQS queue.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_amazon_a_w_s_host" : {
+          "title" : "AWS Host",
+          "description" : "The hostname of the Amazon AWS cloud.",
+          "type" : "string",
+          "default" : "amazonaws.com"
+        },
+        "aws_protocol" : {
+          "title" : "Protocol",
+          "description" : "The underlying protocol used to communicate with SQS",
+          "type" : "string",
+          "example" : "http or https",
+          "default" : "https"
+        },
+        "aws_queue_u_r_l" : {
+          "title" : "Queue URL",
+          "description" : "The full SQS Queue URL (required if using KEDA)",
+          "type" : "string"
+        },
+        "aws_uri_endpoint_override" : {
+          "title" : "Overwrite Endpoint URI",
+          "description" : "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+          "type" : "string"
+        },
+        "aws_override_endpoint" : {
+          "title" : "Endpoint Overwrite",
+          "description" : "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "aws_delay" : {
+          "title" : "Delay",
+          "description" : "Milliseconds before the next poll of the selected stream",
+          "type" : "integer",
+          "default" : 500
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/octet-stream",
+                "enum" : [ "application/octet-stream" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mariadb_sink_0.1.json
+++ b/cypress/fixtures/connectors/mariadb_sink_0.1.json
@@ -1,143 +1,181 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MariaDB Sink",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 3306
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured MariaDB Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured MariaDB Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the MariaDB Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mariadb_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MariaDB Sink",
-    "description" : "MariaDB Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mariadb-sink-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "mariadb-sink",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mariadb-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MariaDB sink",
+    "icon_href" : "TODO",
+    "id" : "mariadb_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "MariaDB sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 3306
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured MariaDB Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured MariaDB Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the MariaDB Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mariadb_source_0.1.json
+++ b/cypress/fixtures/connectors/mariadb_source_0.1.json
@@ -1,149 +1,187 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MariaDB Source",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 3306
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured MariaDB Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured MariaDB Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the MariaDB Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            },
-            "consumedQuery" : {
-              "title" : "Consumed Query",
-              "description" : "A query to run on a tuple consumed",
-              "type" : "string",
-              "example" : "DELETE FROM accounts where user_id = :#user_id"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mariadb_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MariaDB Source",
-    "description" : "MariaDB Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mariadb:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mariadb-source-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "mariadb-source",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mariadb-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MariaDB source",
+    "icon_href" : "TODO",
+    "id" : "mariadb_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "MariaDB source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 3306
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured MariaDB Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured MariaDB Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the MariaDB Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "db_consumed_query" : {
+          "title" : "Consumed Query",
+          "description" : "A query to run on a tuple consumed",
+          "type" : "string",
+          "example" : "DELETE FROM accounts where user_id = :#user_id"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mongodb_sink_0.1.json
+++ b/cypress/fixtures/connectors/mongodb_sink_0.1.json
@@ -1,146 +1,184 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MongoDB Sink",
-          "required" : [ "hosts", "collection", "password", "username", "database" ],
-          "properties" : {
-            "hosts" : {
-              "title" : "MongoDB Hosts",
-              "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
-              "type" : "string"
-            },
-            "collection" : {
-              "title" : "MongoDB Collection",
-              "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "MongoDB Password",
-              "oneOf" : [ {
-                "title" : "MongoDB Password",
-                "description" : "User password for accessing MongoDB.",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "username" : {
-              "title" : "MongoDB Username",
-              "description" : "Username for accessing MongoDB.",
-              "type" : "string"
-            },
-            "database" : {
-              "title" : "MongoDB Database",
-              "description" : "Sets the name of the MongoDB database to target.",
-              "type" : "string"
-            },
-            "writeConcern" : {
-              "title" : "Write Concern",
-              "description" : "Configure the level of acknowledgment requested from MongoDB for write operations, possible values are ACKNOWLEDGED, W1, W2, W3, UNACKNOWLEDGED, JOURNALED, MAJORITY.",
-              "type" : "string"
-            },
-            "createCollection" : {
-              "title" : "Collection",
-              "description" : "Create collection during initialisation if it doesn't exist.",
-              "type" : "boolean",
-              "default" : false
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mongodb_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MongoDB Sink",
-    "description" : "MongoDB Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mongodb-sink-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "cos-mongodb-sink",
+            "prefix" : "mongodb"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mongodb-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MongoDB sink",
+    "icon_href" : "TODO",
+    "id" : "mongodb_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "MongoDB sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "mongodb_hosts", "mongodb_collection", "mongodb_database", "kafka_topic" ],
+      "properties" : {
+        "mongodb_hosts" : {
+          "title" : "MongoDB Hosts",
+          "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
+          "type" : "string"
+        },
+        "mongodb_collection" : {
+          "title" : "MongoDB Collection",
+          "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
+          "type" : "string"
+        },
+        "mongodb_password" : {
+          "title" : "MongoDB Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "MongoDB Password",
+            "description" : "User password for accessing MongoDB.",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the mongodb_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "mongodb_username" : {
+          "title" : "MongoDB Username",
+          "description" : "Username for accessing MongoDB.",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "mongodb_database" : {
+          "title" : "MongoDB Database",
+          "description" : "Sets the name of the MongoDB database to target.",
+          "type" : "string"
+        },
+        "mongodb_write_concern" : {
+          "title" : "Write Concern",
+          "description" : "Configure the level of acknowledgment requested from MongoDB for write operations, possible values are ACKNOWLEDGED, W1, W2, W3, UNACKNOWLEDGED, JOURNALED, MAJORITY.",
+          "type" : "string"
+        },
+        "mongodb_create_collection" : {
+          "title" : "Collection",
+          "description" : "Create collection during initialisation if it doesn't exist.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mongodb_source_0.1.json
+++ b/cypress/fixtures/connectors/mongodb_source_0.1.json
@@ -1,146 +1,184 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MongoDB Source",
-          "required" : [ "hosts", "collection", "password", "username", "database" ],
-          "properties" : {
-            "hosts" : {
-              "title" : "MongoDB Hosts",
-              "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
-              "type" : "string"
-            },
-            "collection" : {
-              "title" : "MongoDB Collection",
-              "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "MongoDB Password",
-              "oneOf" : [ {
-                "title" : "MongoDB Password",
-                "description" : "User password for accessing MongoDB.",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "username" : {
-              "title" : "MongoDB Username",
-              "description" : "Username for accessing MongoDB.",
-              "type" : "string"
-            },
-            "database" : {
-              "title" : "MongoDB Database",
-              "description" : "Sets the name of the MongoDB database to target.",
-              "type" : "string"
-            },
-            "persistentTailTracking" : {
-              "title" : "MongoDB Persistent Tail Tracking",
-              "description" : "Enable persistent tail tracking, which is a mechanism to keep track of the last consumed message across system restarts. The next time the system is up, the endpoint will recover the cursor from the point where it last stopped slurping records.",
-              "type" : "boolean",
-              "default" : false
-            },
-            "tailTrackIncreasingField" : {
-              "title" : "MongoDB Tail Track Increasing Field",
-              "description" : "Correlation field in the incoming record which is of increasing nature and will be used to position the tailing cursor every time it is generated.",
-              "type" : "string"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mongodb_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MongoDB Source",
-    "description" : "MongoDB Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mongodb:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mongodb-source-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "mongodb-source",
+            "prefix" : "mongodb"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mongodb-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MongoDB source",
+    "icon_href" : "TODO",
+    "id" : "mongodb_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "MongoDB source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "mongodb_hosts", "mongodb_collection", "mongodb_database", "kafka_topic" ],
+      "properties" : {
+        "mongodb_hosts" : {
+          "title" : "MongoDB Hosts",
+          "description" : "Comma separated list of MongoDB Host Addresses in host:port format.",
+          "type" : "string"
+        },
+        "mongodb_collection" : {
+          "title" : "MongoDB Collection",
+          "description" : "Sets the name of the MongoDB collection to bind to this endpoint.",
+          "type" : "string"
+        },
+        "mongodb_password" : {
+          "title" : "MongoDB Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "MongoDB Password",
+            "description" : "User password for accessing MongoDB.",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the mongodb_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "mongodb_username" : {
+          "title" : "MongoDB Username",
+          "description" : "Username for accessing MongoDB. The username must be present in the MongoDB's authentication database (authenticationDatabase). By default, the MongoDB authenticationDatabase is 'admin'.",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "mongodb_database" : {
+          "title" : "MongoDB Database",
+          "description" : "Sets the name of the MongoDB database to target.",
+          "type" : "string"
+        },
+        "mongodb_persistent_tail_tracking" : {
+          "title" : "MongoDB Persistent Tail Tracking",
+          "description" : "Enable persistent tail tracking, which is a mechanism to keep track of the last consumed message across system restarts. The next time the system is up, the endpoint will recover the cursor from the point where it last stopped slurping records.",
+          "type" : "boolean",
+          "default" : false
+        },
+        "mongodb_tail_track_increasing_field" : {
+          "title" : "MongoDB Tail Track Increasing Field",
+          "description" : "Correlation field in the incoming record which is of increasing nature and will be used to position the tailing cursor every time it is generated.",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mysql_sink_0.1.json
+++ b/cypress/fixtures/connectors/mysql_sink_0.1.json
@@ -1,143 +1,181 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MySQL Sink",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 3306
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured MySQL Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured MySQL Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the MySQL Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mysql_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MySQL Sink",
-    "description" : "MySQL Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mysql-sink-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "mysql-sink",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mysql-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MySQL sink",
+    "icon_href" : "TODO",
+    "id" : "mysql_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "MySQL sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 3306
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured MySQL Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured MySQL Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the MySQL Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/mysql_source_0.1.json
+++ b/cypress/fixtures/connectors/mysql_source_0.1.json
@@ -1,149 +1,187 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "MySQL Source",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 3306
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured MySQL Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured MySQL Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the MySQL Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            },
-            "consumedQuery" : {
-              "title" : "Consumed Query",
-              "description" : "A query to run on a tuple consumed",
-              "type" : "string",
-              "example" : "DELETE FROM accounts where user_id = :#user_id"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "mysql_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "MySQL Source",
-    "description" : "MySQL Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-mysql:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-mysql-source-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "mysql-source",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "mysql-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "MySQL source",
+    "icon_href" : "TODO",
+    "id" : "mysql_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "MySQL source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 3306
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured MySQL Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured MySQL Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the MySQL Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "db_consumed_query" : {
+          "title" : "Consumed Query",
+          "description" : "A query to run on a tuple consumed",
+          "type" : "string",
+          "example" : "DELETE FROM accounts where user_id = :#user_id"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/postgresql_sink_0.1.json
+++ b/cypress/fixtures/connectors/postgresql_sink_0.1.json
@@ -1,143 +1,181 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "PostgreSQL Sink",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 5432
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured PostgreSQL Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured PostgreSQL Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the PostgreSQL Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "postgresql_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "PostgreSQL Sink",
-    "description" : "PostgreSQL Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-postgresql-sink-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "postgresql-sink",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "postgresql-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "PostgreSQL sink",
+    "icon_href" : "TODO",
+    "id" : "postgresql_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "PostgreSQL sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 5432
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured PostgreSQL Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured PostgreSQL Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the PostgreSQL Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/postgresql_source_0.1.json
+++ b/cypress/fixtures/connectors/postgresql_source_0.1.json
@@ -1,149 +1,187 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "PostgreSQL Source",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 5432
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured PostgreSQL Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured PostgreSQL Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the PostgreSQL Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            },
-            "consumedQuery" : {
-              "title" : "Consumed Query",
-              "description" : "A query to run on a tuple consumed",
-              "type" : "string",
-              "example" : "DELETE FROM accounts where user_id = :#user_id"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "postgresql_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "PostgreSQL Source",
-    "description" : "PostgreSQL Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-postgresql:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-postgresql-source-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "postgresql-source",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "postgresql-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "PostgreSQL source",
+    "icon_href" : "TODO",
+    "id" : "postgresql_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "PostgreSQL source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 5432
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured PostgreSQL Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured PostgreSQL Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the PostgreSQL Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "db_consumed_query" : {
+          "title" : "Consumed Query",
+          "description" : "A query to run on a tuple consumed",
+          "type" : "string",
+          "example" : "DELETE FROM accounts where user_id = :#user_id"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/sqlserver_sink_0.1.json
+++ b/cypress/fixtures/connectors/sqlserver_sink_0.1.json
@@ -1,143 +1,181 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "Microsoft SQL Server Sink",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 1433
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured SQL Server Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured SQL Server Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the SQL Server Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Source",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "sqlserver_sink_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "SQL Server Sink",
-    "description" : "SQL Server Sink",
-    "version" : "0.1",
-    "labels" : [ "sink" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "sink",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-sqlserver-sink-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "sqlserver-sink",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-source",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "sqlserver-sink",
-          "kafka" : "managed-kafka-source",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "SQL Server sink",
+    "icon_href" : "TODO",
+    "id" : "sqlserver_sink_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "sink" ],
+    "name" : "SQL Server sink",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 1433
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured SQL Server Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured SQL Server Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the SQL Server Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "consumes" : {
+              "$ref" : "#/$defs/data_shape/consumes"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "consumes" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/cypress/fixtures/connectors/sqlserver_source_0.1.json
+++ b/cypress/fixtures/connectors/sqlserver_source_0.1.json
@@ -1,149 +1,187 @@
 {
-  "connector_type" : {
-    "json_schema" : {
-      "type" : "object",
-      "properties" : {
-        "connector" : {
-          "type" : "object",
-          "title" : "Microsoft SQL Server Source",
-          "required" : [ "serverName", "username", "password", "query", "databaseName" ],
-          "properties" : {
-            "serverName" : {
-              "title" : "Server Name",
-              "description" : "Server Name for the data source",
-              "type" : "string",
-              "example" : "localhost"
-            },
-            "serverPort" : {
-              "title" : "Server Port",
-              "description" : "Server Port for the data source",
-              "type" : "string",
-              "default" : 1433
-            },
-            "username" : {
-              "title" : "Username",
-              "description" : "The username to use for accessing a secured SQL Server Database",
-              "type" : "string"
-            },
-            "password" : {
-              "title" : "Password",
-              "oneOf" : [ {
-                "title" : "Password",
-                "description" : "The password to use for accessing a secured SQL Server Database",
-                "type" : "string",
-                "format" : "password"
-              }, {
-                "description" : "An opaque reference to the password",
-                "type" : "object",
-                "properties" : { }
-              } ]
-            },
-            "query" : {
-              "title" : "Query",
-              "description" : "The Query to execute against the SQL Server Database",
-              "type" : "string",
-              "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
-            },
-            "databaseName" : {
-              "title" : "Database Name",
-              "description" : "The Database Name we are pointing",
-              "type" : "string"
-            },
-            "consumedQuery" : {
-              "title" : "Consumed Query",
-              "description" : "A query to run on a tuple consumed",
-              "type" : "string",
-              "example" : "DELETE FROM accounts where user_id = :#user_id"
-            }
-          }
-        },
-        "kafka" : {
-          "type" : "object",
-          "title" : "Managed Kafka Sink",
-          "required" : [ "topic" ],
-          "properties" : {
-            "topic" : {
-              "title" : "Topic names",
-              "description" : "Comma separated list of Kafka topic names",
-              "type" : "string"
-            }
-          }
-        },
-        "steps" : {
-          "type" : "array",
-          "items" : {
-            "oneOf" : [ {
-              "type" : "object",
-              "required" : [ "insert-field" ],
-              "properties" : {
-                "insert-field" : {
-                  "title" : "Insert Field Action",
-                  "description" : "Adds a custom field with a constant value to the message in transit.\n\nThis action works with Json Object. So it will expect a Json Array or a Json Object.\n\nIf for example you have an array like '{ \"foo\":\"John\", \"bar\":30 }' and your action has been configured with field as 'element' and value as 'hello', you'll get '{ \"foo\":\"John\", \"bar\":30, \"element\":\"hello\" }'\n\nNo headers mapping supported, only constant values.",
-                  "required" : [ "field", "value" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    },
-                    "value" : {
-                      "title" : "Value",
-                      "description" : "The value of the field",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            }, {
-              "type" : "object",
-              "required" : [ "extract-field" ],
-              "properties" : {
-                "extract-field" : {
-                  "title" : "Extract Field Action",
-                  "description" : "Extract a field from the body",
-                  "required" : [ "field" ],
-                  "properties" : {
-                    "field" : {
-                      "title" : "Field",
-                      "description" : "The name of the field to be added",
-                      "type" : "string"
-                    }
-                  },
-                  "type" : "object"
-                }
-              }
-            } ]
-          }
-        }
-      }
-    },
-    "id" : "sqlserver_source_0.1",
-    "kind" : "ConnectorType",
-    "icon_href" : "TODO",
-    "name" : "SQL Server Source",
-    "description" : "SQL Server Source",
-    "version" : "0.1",
-    "labels" : [ "source" ],
-    "channels" : [ "stable" ]
-  },
   "channels" : {
     "stable" : {
       "shard_metadata" : {
-        "connector_revision" : "3",
+        "annotations" : {
+          "trait.camel.apache.org/container.request-cpu" : "0.20",
+          "trait.camel.apache.org/container.request-memory" : "128m",
+          "trait.camel.apache.org/deployment.progress-deadline-seconds" : "30"
+        },
+        "connector_image" : "quay.io/rhoas/cos-connector-sqlserver:0.1.29",
+        "connector_revision" : "29",
         "connector_type" : "source",
-        "connector_image" : "quay.io/lburgazzoli/mci:0.1.3-sqlserver-source-0.1",
+        "consumes" : "application/json",
+        "error_handler_strategy" : "stop",
+        "kamelets" : {
+          "adapter" : {
+            "name" : "sqlserver-source",
+            "prefix" : "db"
+          },
+          "kafka" : {
+            "name" : "cos-kafka-sink",
+            "prefix" : "kafka"
+          }
+        },
         "operators" : [ {
           "type" : "camel-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
-        "kamelets" : {
-          "connector" : "sqlserver-source",
-          "kafka" : "managed-kafka-sink",
-          "insert-field" : "insert-field-action",
-          "extract-field" : "extract-field-action"
-        }
+        "produces" : "application/json"
       }
     }
+  },
+  "connector_type" : {
+    "capabilities" : [ "data_shape", "error_handler", "processors" ],
+    "channels" : [ "stable" ],
+    "description" : "SQL Server source",
+    "icon_href" : "TODO",
+    "id" : "sqlserver_source_0.1",
+    "kind" : "ConnectorType",
+    "labels" : [ "source" ],
+    "name" : "SQL Server source",
+    "schema" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "db_server_name", "db_username", "db_password", "db_query", "db_database_name", "kafka_topic" ],
+      "properties" : {
+        "db_server_name" : {
+          "title" : "Server Name",
+          "description" : "Server Name for the data source",
+          "type" : "string",
+          "example" : "localhost"
+        },
+        "db_server_port" : {
+          "title" : "Server Port",
+          "description" : "Server Port for the data source",
+          "type" : "string",
+          "default" : 1433
+        },
+        "db_username" : {
+          "title" : "Username",
+          "description" : "The username to use for accessing a secured SQL Server Database",
+          "type" : "string",
+          "x-group" : "credentials"
+        },
+        "db_password" : {
+          "title" : "Password",
+          "x-group" : "credentials",
+          "oneOf" : [ {
+            "title" : "Password",
+            "description" : "The password to use for accessing a secured SQL Server Database",
+            "type" : "string",
+            "format" : "password"
+          }, {
+            "description" : "An opaque reference to the db_password",
+            "type" : "object",
+            "properties" : { }
+          } ]
+        },
+        "db_query" : {
+          "title" : "Query",
+          "description" : "The Query to execute against the SQL Server Database",
+          "type" : "string",
+          "example" : "INSERT INTO accounts (username,city) VALUES (:#username,:#city)"
+        },
+        "db_database_name" : {
+          "title" : "Database Name",
+          "description" : "The Database Name we are pointing",
+          "type" : "string"
+        },
+        "db_consumed_query" : {
+          "title" : "Consumed Query",
+          "description" : "A query to run on a tuple consumed",
+          "type" : "string",
+          "example" : "DELETE FROM accounts where user_id = :#user_id"
+        },
+        "kafka_topic" : {
+          "title" : "Topic Names",
+          "description" : "Comma separated list of Kafka topic names",
+          "type" : "string"
+        },
+        "data_shape" : {
+          "type" : "object",
+          "additionalProperties" : false,
+          "properties" : {
+            "produces" : {
+              "$ref" : "#/$defs/data_shape/produces"
+            }
+          }
+        },
+        "error_handler" : {
+          "type" : "object",
+          "oneOf" : [ {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "log" ],
+            "properties" : {
+              "log" : {
+                "$ref" : "#/$defs/error_handler/log"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "stop" ],
+            "properties" : {
+              "stop" : {
+                "$ref" : "#/$defs/error_handler/stop"
+              }
+            }
+          }, {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "dead_letter_queue" ],
+            "properties" : {
+              "dead_letter_queue" : {
+                "$ref" : "#/$defs/error_handler/dead_letter_queue"
+              }
+            }
+          } ],
+          "default" : {
+            "stop" : { }
+          }
+        },
+        "processors" : { }
+      },
+      "$defs" : {
+        "data_shape" : {
+          "produces" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "format" ],
+            "properties" : {
+              "format" : {
+                "type" : "string",
+                "default" : "application/json",
+                "enum" : [ "application/json" ]
+              }
+            }
+          }
+        },
+        "error_handler" : {
+          "log" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "stop" : {
+            "type" : "object",
+            "additionalProperties" : false
+          },
+          "dead_letter_queue" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "required" : [ "topic" ],
+            "properties" : {
+              "topic" : {
+                "type" : "string",
+                "title" : "Dead Letter Topic Name",
+                "description" : "The name of the Kafka topic used as dead letter queue"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version" : "0.1"
   }
 }

--- a/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
+++ b/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
@@ -90,7 +90,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
   }
 
   getField(name: string): Record<string, any> {
-    const { oneOf, ...field } = super.getField(name);
+    const { enum: enumValues, oneOf, ...field } = super.getField(name);
     // use this to look at field information
     /*
     console.log(
@@ -102,6 +102,18 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
       field
     );
     */
+    // uniforms will show the first enum value even if the underlying
+    // model object doesn't have this set or if there's no default value
+    let newEnumValues = undefined;
+    if (
+      typeof field.type !== 'undefined' &&
+      field.type === 'string' &&
+      typeof enumValues !== 'undefined'
+    ) {
+      if (enumValues[0] !== '') {
+        newEnumValues = ['', ...enumValues];
+      }
+    }
     // Due to:
     // https://uniforms.tools/docs/api-bridges/#note-on-allofanyofoneof
     // we need to pick the appropriate type for the form, let's use the
@@ -119,7 +131,11 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
         isSecret: asString.format === 'password',
       };
     } else {
-      return { name, ...field };
+      return {
+        name,
+        ...field,
+        ...(typeof newEnumValues !== undefined && { enum: newEnumValues }),
+      };
     }
   }
 }

--- a/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.stories.tsx
+++ b/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.stories.tsx
@@ -45,7 +45,9 @@ const Template: ComponentStory<typeof JsonSchemaConfigurator> = (
   return (
     <JsonSchemaConfigurator
       {...args}
-      schema={fixture.connector_type.json_schema}
+      schema={
+        fixture.connector_type.json_schema || fixture.connector_type.schema
+      }
     />
   );
 };


### PR DESCRIPTION
This change addresses how uniforms can represent what is valid data in
an inconsistent way.  For enums if the underlying model object is unset,
uniforms will still show the first enum value, leading the user to
believe that the field is configured.  This change works around this by
inserting empty enum values as needed into the schema definition so it's
not necessary for the schema to have to deal with a UI concern.

With this change the connector creation wizard will require the user to select the appropriate region:

![image](https://user-images.githubusercontent.com/351660/172638172-398c8c3f-7231-46d6-bace-5711b8dcf316.png)

I also opted to manually update the fixtures from the current catalog in this commit as well, maybe this is something that could be automated in the future.

