### PR TITLE
MGDCTRS-968 fix: show all the connectors

### DIFF
--- a/src/app/machines/PaginatedResponse.machine.ts
+++ b/src/app/machines/PaginatedResponse.machine.ts
@@ -5,6 +5,8 @@ import { ActorRef, ActorRefFrom, Sender, spawn } from 'xstate';
 import { pure, sendParent } from 'xstate/lib/actions';
 import { createModel } from 'xstate/lib/model';
 
+const DEFAULT_PAGE_SIZE = 10;
+
 export type ApiErrorResponse = { page: number; error: string };
 export type ApiSuccessResponse<RawDataType> = {
   items: Array<RawDataType>;
@@ -60,15 +62,21 @@ export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
   service: ApiCallback<RawDataType, QueryType>,
   dataTransformer: (response: RawDataType) => DataType,
   options?: {
+    defaultSize?: number;
     pollingEnabled?: boolean;
     onBeforeSetResponse?: (previousResponse: DataType[] | undefined) => void;
   }
 ) {
+  const size = options
+    ? typeof options?.defaultSize !== 'undefined'
+      ? options?.defaultSize
+      : DEFAULT_PAGE_SIZE
+    : DEFAULT_PAGE_SIZE;
   const model = createModel(
     {
       request: {
         page: 1,
-        size: 10,
+        size,
       },
       response: undefined,
       pollingEnabled: options?.pollingEnabled || false,

--- a/src/app/machines/StepConnectorTypes.machine.ts
+++ b/src/app/machines/StepConnectorTypes.machine.ts
@@ -15,6 +15,8 @@ import {
   makePaginatedApiMachine,
 } from './PaginatedResponse.machine';
 
+export const DEFAULT_CONNECTOR_TYPES_PAGE_SIZE = 500;
+
 type Context = {
   accessToken: () => Promise<string>;
   connectorsApiBasePath: string;
@@ -90,7 +92,9 @@ export const connectorTypesMachine = model.createMachine(
                   ConnectorType,
                   ConnectorTypesQuery,
                   ConnectorType
-                >(fetchConnectorTypes(context), (i) => i),
+                >(fetchConnectorTypes(context), (i) => i, {
+                  defaultSize: DEFAULT_CONNECTOR_TYPES_PAGE_SIZE,
+                }),
             },
             states: {
               idle: {

--- a/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
@@ -5,8 +5,9 @@ import {
 import { EmptyStateGenericError } from '@app/components/EmptyStateGenericError/EmptyStateGenericError';
 import { EmptyStateNoMatchesFound } from '@app/components/EmptyStateNoMatchesFound/EmptyStateNoMatchesFound';
 import { Loading } from '@app/components/Loading/Loading';
-import { Pagination } from '@app/components/Pagination/Pagination';
+// import { Pagination } from '@app/components/Pagination/Pagination';
 import { StepBodyLayout } from '@app/components/StepBodyLayout/StepBodyLayout';
+import { DEFAULT_CONNECTOR_TYPES_PAGE_SIZE } from '@app/machines/StepConnectorTypes.machine';
 import React, {
   FunctionComponent,
   useCallback,
@@ -85,7 +86,12 @@ export function ConnectorTypesGallery() {
               <>
                 <ConnectorTypesToolbar duplicateMode={duplicateMode} />
                 <EmptyStateNoMatchesFound
-                  onClear={() => onQuery({ page: 1, size: 10 })}
+                  onClear={() =>
+                    onQuery({
+                      page: 1,
+                      size: DEFAULT_CONNECTOR_TYPES_PAGE_SIZE,
+                    })
+                  }
                 />
               </>
             );
@@ -350,6 +356,7 @@ const ConnectorTypesToolbar: FunctionComponent<ConnectorTypesToolbarProps> = ({
       <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
         {toggleGroupItems}
       </ToolbarToggleGroup>
+      {/*
       {!duplicateMode && (
         <ToolbarItem variant="pagination" alignment={{ default: 'alignRight' }}>
           <ConnectorTypesPagination
@@ -360,6 +367,7 @@ const ConnectorTypesToolbar: FunctionComponent<ConnectorTypesToolbarProps> = ({
           />
         </ToolbarItem>
       )}
+      */}
     </>
   );
   return (
@@ -375,6 +383,7 @@ const ConnectorTypesToolbar: FunctionComponent<ConnectorTypesToolbarProps> = ({
   );
 };
 
+/*
 type ConnectorTypesPaginationProps = {
   isCompact?: boolean;
   onChange: (page: number, size: number) => void;
@@ -392,3 +401,4 @@ const ConnectorTypesPagination: FunctionComponent<ConnectorTypesPaginationProps>
       />
     );
   };
+*/


### PR DESCRIPTION
This change is intended to temporarily remove the pagination control for
the connector types step in the connector creation wizard so that all
connector types are visible to the user when the step loads.  It also
adds an argument to the pagination machine so that a given view can
control the default page size.

@indraraj @uidoyen let's hold off merging this until we decide we need it, but may as well get the change open :-)
