### PR TITLE
MGDCTRS-772 feat: server-side filtering/ordering

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,12 +4,12 @@
   "env": {
     "homepage": "/",
     "wizard": "/create-connector",
-    "connectorsApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors?page=1&size=10",
+    "connectorsApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors?page=1&size=10&orderBy=&search=",
     "connectorsActionApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors/",
-    "connectorTypesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_types?page=1&size=1000",
+    "connectorTypesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_types?page=1&size=10&search=",
     "kafkasApiPath": "https://api.openshift.com/api/kafkas_mgmt/v1/kafkas?page=1&size=10&search=",
     "namespaceApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_namespaces/c9ns6husvba2r48dqnd0",
-    "namespacesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_namespaces?page=1&size=10",
+    "namespacesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_namespaces?page=1&size=10&search=",
     "serviceAccountApiPath": "https://api.openshift.com/api/kafkas_mgmt/v1/service_accounts",
     "connectorCreationApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors?async=true"
   },

--- a/cypress.json
+++ b/cypress.json
@@ -6,7 +6,7 @@
     "wizard": "/create-connector",
     "connectorsApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors?page=1&size=10&orderBy=&search=",
     "connectorsActionApiPath": "/localhost/api/connector_mgmt/v1/kafka_connectors/",
-    "connectorTypesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_types?page=1&size=10&search=",
+    "connectorTypesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_types?page=1&size=20&search=",
     "kafkasApiPath": "https://api.openshift.com/api/kafkas_mgmt/v1/kafkas?page=1&size=10&search=",
     "namespaceApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_namespaces/c9ns6husvba2r48dqnd0",
     "namespacesApiPath": "/localhost/api/connector_mgmt/v1/kafka_connector_namespaces?page=1&size=10&search=",

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -13,7 +13,6 @@ import {
   ConnectorNamespacesApi,
   ConnectorsApi,
   ConnectorType,
-  ConnectorTypeAllOf,
   ConnectorTypesApi,
   ObjectReference,
   ServiceAccount,
@@ -23,6 +22,15 @@ import {
   DefaultApi,
   SecurityApi,
 } from '@rhoas/kafka-management-sdk';
+
+import { PlaceholderOrderBy } from './../app/machines/PaginatedResponse.machine';
+
+export enum SortOrderValue {
+  asc = 'asc',
+  desc = 'desc',
+}
+
+export type SortOrder = keyof typeof SortOrderValue;
 
 type CommonApiProps = {
   accessToken: () => Promise<string>;
@@ -261,10 +269,26 @@ export const getConnectorTypeDetail = ({
   };
 };
 
+export type ConnectorsOrderBy = {
+  name?: SortOrder;
+};
+
+export type ConnectorsSearch = {
+  name?: string;
+  description?: string;
+  version?: string;
+  label?: string[];
+  channel?: string;
+};
+
 export const fetchConnectors = ({
   accessToken,
   connectorsApiBasePath,
-}: CommonApiProps): ApiCallback<Connector, {}> => {
+}: CommonApiProps): ApiCallback<
+  Connector,
+  ConnectorsOrderBy,
+  ConnectorsSearch
+> => {
   const connectorsAPI = new ConnectorsApi(
     new Configuration({
       accessToken,
@@ -274,10 +298,16 @@ export const fetchConnectors = ({
   return (request, onSuccess, onError) => {
     const CancelToken = axios.CancelToken;
     const source = CancelToken.source();
-    const { page, size /*, name = '' */ } = request;
-    // const query = name.length > 0 ? `name LIKE ${name}` : undefined;
+    const { page, size, search } = request;
+    const { name } = search || {};
+    const nameSearch =
+      name && name.length > 0 ? ` name like %${name}%` : undefined;
+    const searchString: string = [nameSearch]
+      .filter(Boolean)
+      .map((s) => `(${s})`)
+      .join(' AND ');
     connectorsAPI
-      .listConnectors(`${page}`, `${size}`, undefined, undefined, {
+      .listConnectors(`${page}`, `${size}`, '', searchString, {
         cancelToken: source.token,
       })
       .then((response) => {
@@ -369,10 +399,18 @@ export const getNamespace = ({
   };
 };
 
+export type ConnectorNamespaceSearch = {
+  name?: string;
+};
+
 export const fetchConnectorNamespaces = ({
   accessToken,
   connectorsApiBasePath,
-}: CommonApiProps): ApiCallback<ConnectorNamespace, {}> => {
+}: CommonApiProps): ApiCallback<
+  ConnectorNamespace,
+  PlaceholderOrderBy,
+  ConnectorNamespaceSearch
+> => {
   const namespacesAPI = new ConnectorNamespacesApi(
     new Configuration({
       accessToken,
@@ -382,9 +420,16 @@ export const fetchConnectorNamespaces = ({
   return (request, onSuccess, onError) => {
     const CancelToken = axios.CancelToken;
     const source = CancelToken.source();
-    const { page, size } = request;
+    const { page, size, search } = request;
+    const { name } = search || {};
+    const nameSearch =
+      name && name.length > 0 ? ` name like %${name}%` : undefined;
+    const searchString: string = [nameSearch]
+      .filter(Boolean)
+      .map((s) => `(${s})`)
+      .join(' AND ');
     namespacesAPI
-      .listConnectorNamespaces(`${page}`, `${size}`)
+      .listConnectorNamespaces(`${page}`, `${size}`, undefined, searchString)
       .then((response) => {
         onSuccess({
           items: response.data.items || [],
@@ -403,15 +448,29 @@ export const fetchConnectorNamespaces = ({
     };
   };
 };
-export type ConnectorTypesQuery = {
+
+export type ConnectorTypesSearch = {
   name?: string;
   categories?: string[];
+
+  description?: string;
+  version?: string;
+  label?: string[];
+  channel?: string;
+};
+
+export type ConnectorTypesOrderBy = {
+  name?: SortOrder;
 };
 
 export const fetchConnectorTypes = ({
   accessToken,
   connectorsApiBasePath,
-}: CommonApiProps): ApiCallback<ConnectorType, ConnectorTypesQuery> => {
+}: CommonApiProps): ApiCallback<
+  ConnectorType,
+  PlaceholderOrderBy,
+  ConnectorTypesSearch
+> => {
   const connectorsAPI = new ConnectorTypesApi(
     new Configuration({
       accessToken,
@@ -421,39 +480,28 @@ export const fetchConnectorTypes = ({
   return (request, onSuccess, onError) => {
     const CancelToken = axios.CancelToken;
     const source = CancelToken.source();
-    const { page, size, query } = request;
-    const { name, categories = [] } = query || {};
+    const { page, size, search } = request;
+    const { name, categories = [] } = search || {};
+    const nameSearch =
+      name && name.length > 0 ? ` name like %${name}%` : undefined;
+    const labelSearch =
+      categories && categories.length > 0
+        ? categories.map((s) => `label = ${s}`).join(' OR ')
+        : undefined;
+    const searchString: string = [nameSearch, labelSearch]
+      .filter(Boolean)
+      .map((s) => `(${s})`)
+      .join(' AND ');
     connectorsAPI
-      .getConnectorTypes('1', '1000', undefined, undefined, {
+      .getConnectorTypes(`${page}`, `${size}`, undefined, searchString, {
         cancelToken: source.token,
       })
       .then((response) => {
-        const lcName = name ? name.toLowerCase() : undefined;
-        const rawItems = response.data.items || [];
-        let filteredItems = lcName
-          ? rawItems?.filter((c) =>
-              (c as ConnectorTypeAllOf).name?.toLowerCase().includes(lcName)
-            )
-          : rawItems;
-        filteredItems =
-          categories.length > 0
-            ? filteredItems?.filter(
-                (c) =>
-                  (
-                    (c as ConnectorTypeAllOf).labels?.filter((l) =>
-                      categories.includes(l)
-                    ) || []
-                  ).length > 0
-              )
-            : filteredItems;
-        const total = filteredItems.length;
-        const offset = (page - 1) * size;
-        const items = filteredItems.slice(offset, offset + size);
         onSuccess({
-          items,
-          total,
-          page,
-          size,
+          items: response.data.items || [],
+          total: response.data.total,
+          page: response.data.page,
+          size: response.data.size,
         });
       })
       .catch((error) => {
@@ -472,7 +520,7 @@ type KafkaManagementApiProps = {
   kafkaManagementBasePath: string;
 };
 
-export type KafkasQuery = {
+export type KafkasSearch = {
   name?: string;
   owner?: string;
   statuses?: string[];
@@ -483,7 +531,11 @@ export type KafkasQuery = {
 export const fetchKafkaInstances = ({
   accessToken,
   kafkaManagementBasePath,
-}: KafkaManagementApiProps): ApiCallback<KafkaRequest, KafkasQuery> => {
+}: KafkaManagementApiProps): ApiCallback<
+  KafkaRequest,
+  PlaceholderOrderBy,
+  KafkasSearch
+> => {
   const connectorsAPI = new DefaultApi(
     new Configuration({
       accessToken,
@@ -493,12 +545,12 @@ export const fetchKafkaInstances = ({
   return (request, onSuccess, onError) => {
     const CancelToken = axios.CancelToken;
     const source = CancelToken.source();
-    const { page, size, query } = request;
-    const { name, statuses, owner, cloudProviders, regions } = query || {};
+    const { page, size, search } = request;
+    const { name, statuses, owner, cloudProviders, regions } = search || {};
     const nameSearch =
-      name && name.length > 0 ? ` name LIKE ${name}` : undefined;
+      name && name.length > 0 ? ` name LIKE %${name}%` : undefined;
     const ownerSearch =
-      owner && owner.length > 0 ? ` owner LIKE ${owner}` : undefined;
+      owner && owner.length > 0 ? ` owner LIKE %${owner}%` : undefined;
     const statusSearch =
       statuses && statuses.length > 0
         ? statuses.map((s) => `status = ${s}`).join(' OR ')
@@ -511,7 +563,7 @@ export const fetchKafkaInstances = ({
       regions && regions.length > 0
         ? regions.map((s) => `region = ${s}`).join(' OR ')
         : undefined;
-    const search = [
+    const searchString = [
       nameSearch,
       ownerSearch,
       statusSearch,
@@ -522,15 +574,9 @@ export const fetchKafkaInstances = ({
       .map((s) => `(${s})`)
       .join(' AND ');
     connectorsAPI
-      .getKafkas(
-        `${page}`,
-        `${size}`,
-        undefined,
-        search as string | undefined,
-        {
-          cancelToken: source.token,
-        }
-      )
+      .getKafkas(`${page}`, `${size}`, undefined, searchString, {
+        cancelToken: source.token,
+      })
       .then((response) => {
         onSuccess({
           items: response.data.items || [],

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -301,7 +301,7 @@ export const fetchConnectors = ({
     const { page, size, search } = request;
     const { name } = search || {};
     const nameSearch =
-      name && name.length > 0 ? ` name like %${name}%` : undefined;
+      name && name.length > 0 ? ` name like '%${name}%'` : undefined;
     const searchString: string = [nameSearch]
       .filter(Boolean)
       .map((s) => `(${s})`)
@@ -423,7 +423,7 @@ export const fetchConnectorNamespaces = ({
     const { page, size, search } = request;
     const { name } = search || {};
     const nameSearch =
-      name && name.length > 0 ? ` name like %${name}%` : undefined;
+      name && name.length > 0 ? ` name like '%${name}%'` : undefined;
     const searchString: string = [nameSearch]
       .filter(Boolean)
       .map((s) => `(${s})`)
@@ -483,7 +483,7 @@ export const fetchConnectorTypes = ({
     const { page, size, search } = request;
     const { name, categories = [] } = search || {};
     const nameSearch =
-      name && name.length > 0 ? ` name like %${name}%` : undefined;
+      name && name.length > 0 ? ` name like '%${name}%'` : undefined;
     const labelSearch =
       categories && categories.length > 0
         ? categories.map((s) => `label = ${s}`).join(' OR ')
@@ -548,9 +548,9 @@ export const fetchKafkaInstances = ({
     const { page, size, search } = request;
     const { name, statuses, owner, cloudProviders, regions } = search || {};
     const nameSearch =
-      name && name.length > 0 ? ` name LIKE %${name}%` : undefined;
+      name && name.length > 0 ? ` name LIKE '%${name}%'` : undefined;
     const ownerSearch =
-      owner && owner.length > 0 ? ` owner LIKE %${owner}%` : undefined;
+      owner && owner.length > 0 ? ` owner LIKE '%${owner}%'` : undefined;
     const statusSearch =
       statuses && statuses.length > 0
         ? statuses.map((s) => `status = ${s}`).join(' OR ')

--- a/src/app/components/ConnectorsToolbar/ConnectorsToolbar.tsx
+++ b/src/app/components/ConnectorsToolbar/ConnectorsToolbar.tsx
@@ -1,28 +1,86 @@
+import { ConnectorsOrderBy, ConnectorsSearch } from '@apis/api';
 import {
   Pagination,
   PaginationProps,
 } from '@app/components/Pagination/Pagination';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
 
 import {
+  Button,
+  InputGroup,
+  TextInput,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 
-type ConnectorsToolbarProps = {} & PaginationProps;
+type ConnectorsToolbarProps = {} & PaginationProps<
+  ConnectorsOrderBy,
+  ConnectorsSearch
+>;
 export const ConnectorsToolbar: FunctionComponent<ConnectorsToolbarProps> = ({
   itemCount,
   page,
   perPage,
   onChange,
+  orderBy,
+  search,
 }) => {
   const { t } = useTranslation();
+  // this is until we add a search field selector for other fields
+  const initialName = search ? search.name || '' : '';
+  const [name, setName] = useState<string>(initialName);
+  const runQuery = () => {
+    onChange({
+      page: 1,
+      size: perPage,
+      orderBy,
+      search: {
+        name,
+      },
+    });
+  };
+  const toggleGroupItems = (
+    <>
+      <ToolbarItem>
+        <InputGroup>
+          <TextInput
+            name="name"
+            id="name"
+            type="search"
+            aria-label="filter by connector name"
+            value={`${name}`}
+            ouiaId={'search-field'}
+            onChange={setName}
+            onKeyUp={(event) => {
+              if (event.key === 'Enter') {
+                runQuery();
+              }
+            }}
+          />
+          <Button
+            variant={'control'}
+            aria-label="search button for search input"
+            onClick={runQuery}
+            ouiaId={'button-search'}
+          >
+            <SearchIcon />
+          </Button>
+        </InputGroup>
+      </ToolbarItem>
+    </>
+  );
+
   const toolbarItems = (
     <>
+      <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+        {toggleGroupItems}
+      </ToolbarToggleGroup>
       <ToolbarGroup variant="icon-button-group">
         <ToolbarItem>
           <NavLink
@@ -39,7 +97,13 @@ export const ConnectorsToolbar: FunctionComponent<ConnectorsToolbarProps> = ({
           itemCount={itemCount}
           page={page}
           perPage={perPage}
-          onChange={onChange}
+          onChange={(event) =>
+            onChange({
+              ...event,
+              orderBy: orderBy,
+              search: search,
+            })
+          }
           isCompact={true}
         />
       </ToolbarItem>

--- a/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
+++ b/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
@@ -1,6 +1,7 @@
 import {
-  ConnectorTypesQuery,
-  KafkasQuery,
+  ConnectorTypesOrderBy,
+  ConnectorTypesSearch,
+  KafkasSearch,
   UserProvidedServiceAccount,
 } from '@apis/api';
 import {
@@ -11,6 +12,8 @@ import {
   usePagination,
   PaginatedApiActorType,
   PaginatedApiRequest,
+  PlaceholderOrderBy,
+  PlaceholderSearch,
 } from '@app/machines/PaginatedResponse.machine';
 import { BasicMachineActorRef } from '@app/machines/StepCommon.machine';
 import {
@@ -158,10 +161,20 @@ export const useNamespaceMachineIsReady = () => {
 
 export const useNamespaceMachine = () => {
   const { namespaceRef } = useCreateConnectorWizard();
-  const api = usePagination<ConnectorNamespace, {}, ConnectorNamespace>(
+  const api = usePagination<
+    ConnectorNamespace,
+    PlaceholderOrderBy,
+    PlaceholderSearch,
+    ConnectorNamespace
+  >(
     namespaceRef.getSnapshot()?.children[
       PAGINATED_MACHINE_ID
-    ] as PaginatedApiActorType<ConnectorNamespace, {}, ConnectorNamespace>
+    ] as PaginatedApiActorType<
+      ConnectorNamespace,
+      PlaceholderOrderBy,
+      PlaceholderSearch,
+      ConnectorNamespace
+    >
   );
   const { selectedId, duplicateMode } = useSelector(
     namespaceRef,
@@ -184,8 +197,8 @@ export const useNamespaceMachine = () => {
     namespaceRef.send({ type: 'deselectNamespace' });
   }, [namespaceRef]);
 
-  const onQuery = useCallback(
-    (request: PaginatedApiRequest<{}>) => {
+  const runQuery = useCallback(
+    (request: PaginatedApiRequest<PlaceholderOrderBy, PlaceholderSearch>) => {
       namespaceRef.send({ type: 'api.query', ...request });
     },
     [namespaceRef]
@@ -201,7 +214,7 @@ export const useNamespaceMachine = () => {
     onSelect,
     onDeselect,
     onRefresh,
-    onQuery,
+    runQuery,
   };
 };
 
@@ -221,12 +234,18 @@ export const useConnectorTypesMachineIsReady = () => {
 
 export const useConnectorTypesMachine = () => {
   const { connectorTypeRef } = useCreateConnectorWizard();
-  const api = usePagination<ConnectorType, ConnectorTypesQuery, ConnectorType>(
+  const api = usePagination<
+    ConnectorType,
+    ConnectorTypesOrderBy,
+    ConnectorTypesSearch,
+    ConnectorType
+  >(
     connectorTypeRef.getSnapshot()?.children[
       PAGINATED_MACHINE_ID
     ] as PaginatedApiActorType<
       ConnectorType,
-      ConnectorTypesQuery,
+      ConnectorTypesOrderBy,
+      ConnectorTypesSearch,
       ConnectorType
     >
   );
@@ -248,8 +267,10 @@ export const useConnectorTypesMachine = () => {
     },
     [connectorTypeRef]
   );
-  const onQuery = useCallback(
-    (request: PaginatedApiRequest<ConnectorTypesQuery>) => {
+  const runQuery = useCallback(
+    (
+      request: PaginatedApiRequest<ConnectorTypesOrderBy, ConnectorTypesSearch>
+    ) => {
       connectorTypeRef.send({ type: 'api.query', ...request });
     },
     [connectorTypeRef]
@@ -258,7 +279,7 @@ export const useConnectorTypesMachine = () => {
     ...api,
     selectedId,
     onSelect,
-    onQuery,
+    runQuery,
     connectorTypeDetails,
     duplicateMode,
   };
@@ -280,10 +301,20 @@ export const useKafkasMachineIsReady = () => {
 
 export const useKafkasMachine = () => {
   const { kafkaRef } = useCreateConnectorWizard();
-  const api = usePagination<KafkaRequest, KafkasQuery, KafkaRequest>(
+  const api = usePagination<
+    KafkaRequest,
+    PlaceholderOrderBy,
+    KafkasSearch,
+    KafkaRequest
+  >(
     kafkaRef.getSnapshot()?.children[
       PAGINATED_MACHINE_ID
-    ] as PaginatedApiActorType<KafkaRequest, KafkasQuery, KafkaRequest>
+    ] as PaginatedApiActorType<
+      KafkaRequest,
+      PlaceholderOrderBy,
+      KafkasSearch,
+      KafkaRequest
+    >
   );
   const { selectedId, duplicateMode } = useSelector(
     kafkaRef,
@@ -306,8 +337,8 @@ export const useKafkasMachine = () => {
     kafkaRef.send({ type: 'deselectInstance' });
   }, [kafkaRef]);
 
-  const onQuery = useCallback(
-    (request: PaginatedApiRequest<KafkasQuery>) => {
+  const runQuery = useCallback(
+    (request: PaginatedApiRequest<PlaceholderOrderBy, KafkasSearch>) => {
       kafkaRef.send({ type: 'api.query', ...request });
     },
     [kafkaRef]
@@ -318,7 +349,7 @@ export const useKafkasMachine = () => {
     duplicateMode,
     onSelect,
     onDeselect,
-    onQuery,
+    runQuery,
   };
 };
 

--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -2,14 +2,23 @@ import React, { FunctionComponent } from 'react';
 
 import { Pagination as PFPagination } from '@patternfly/react-core';
 
-export type PaginationProps = {
+export type PaginationEvent<OrderBy, Search> = {
+  page: number;
+  size: number;
+  orderBy?: OrderBy;
+  search?: Search;
+};
+
+export type PaginationProps<OrderBy, Search> = {
   itemCount: number;
   page: number;
   perPage: number;
   isCompact?: boolean;
-  onChange: (page: number, perPage: number) => void;
+  onChange: (event: PaginationEvent<OrderBy, Search>) => void;
+  orderBy?: OrderBy;
+  search?: Search;
 };
-export const Pagination: FunctionComponent<PaginationProps> = ({
+export const Pagination: FunctionComponent<PaginationProps<object, object>> = ({
   itemCount,
   page,
   perPage,
@@ -44,8 +53,8 @@ export const Pagination: FunctionComponent<PaginationProps> = ({
       page={page}
       perPage={perPage}
       perPageOptions={defaultPerPageOptions}
-      onSetPage={(_, page) => onChange(page, perPage)}
-      onPerPageSelect={(_, perPage) => onChange(page, perPage)}
+      onSetPage={(_, page) => onChange({ page, size: perPage })}
+      onPerPageSelect={(_, perPage) => onChange({ page: 1, size: perPage })}
       variant={isCompact ? 'top' : 'bottom'}
       isCompact={isCompact}
     />

--- a/src/app/machines/ConnectorsPage.machine.ts
+++ b/src/app/machines/ConnectorsPage.machine.ts
@@ -1,4 +1,8 @@
-import { fetchConnectors } from '@apis/api';
+import {
+  ConnectorsOrderBy,
+  ConnectorsSearch,
+  fetchConnectors,
+} from '@apis/api';
 import { PAGINATED_MACHINE_ID } from '@constants/constants';
 
 import { InterpreterFrom, send, spawn } from 'xstate';
@@ -32,7 +36,8 @@ const model = createModel(
     events: {
       ...getPaginatedApiMachineEvents<
         Connector,
-        {},
+        ConnectorsOrderBy,
+        ConnectorsSearch,
         ConnectorMachineActorRef
       >(),
       selectConnector: (payload: { connector: Connector }) => payload,
@@ -73,7 +78,8 @@ export const connectorsPageMachine = model.createMachine(
               src: (context) =>
                 makePaginatedApiMachine<
                   Connector,
-                  {},
+                  ConnectorsOrderBy,
+                  ConnectorsSearch,
                   ConnectorMachineActorRef
                 >(
                   fetchConnectors(context),

--- a/src/app/machines/PaginatedResponse.machine.ts
+++ b/src/app/machines/PaginatedResponse.machine.ts
@@ -12,24 +12,26 @@ export type ApiSuccessResponse<RawDataType> = {
   size: number;
   total: number;
 };
-export type ApiCallback<RawDataType, QueryType> = (
-  request: PaginatedApiRequest<QueryType>,
+export type ApiCallback<RawDataType, OrderBy, Search> = (
+  request: PaginatedApiRequest<OrderBy, Search>,
   onSuccess: (payload: ApiSuccessResponse<RawDataType>) => void,
   onError: (payload: ApiErrorResponse) => void
 ) => () => void;
-
-export type PaginatedApiRequest<QueryType> = {
+export type PlaceholderOrderBy = object;
+export type PlaceholderSearch = object;
+export type PaginatedApiRequest<OrderBy, Search> = {
   page: number;
   size: number;
-  query?: QueryType;
+  orderBy?: OrderBy;
+  search?: Search;
 };
 export type PaginatedApiResponse<DataType> = {
   total: number;
   items?: Array<DataType>;
   error?: string;
 };
-export type PaginatedMachineContext<RawDataType, QueryType, DataType> = {
-  request: PaginatedApiRequest<QueryType>;
+export type PaginatedMachineContext<RawDataType, OrderBy, Search, DataType> = {
+  request: PaginatedApiRequest<OrderBy, Search>;
   response?: PaginatedApiResponse<DataType>;
   pollingEnabled: boolean;
   actor?: ActorRef<any>;
@@ -39,25 +41,26 @@ export type PaginatedMachineContext<RawDataType, QueryType, DataType> = {
 
 export const getPaginatedApiMachineEvents = <
   RawDataType,
-  QueryType,
+  OrderBy,
+  Search,
   DataType
 >() => ({
   'api.refresh': () => ({}),
   'api.nextPage': () => ({}),
   'api.prevPage': () => ({}),
-  'api.query': (payload: PaginatedApiRequest<QueryType>) => payload,
+  'api.query': (payload: PaginatedApiRequest<OrderBy, Search>) => payload,
   'api.setResponse': (payload: ApiSuccessResponse<RawDataType>) => payload,
   'api.setError': (payload: ApiErrorResponse) => payload,
 
   // notifyParent
   'api.ready': () => ({}),
-  'api.loading': (payload: PaginatedApiRequest<QueryType>) => payload,
+  'api.loading': (payload: PaginatedApiRequest<OrderBy, Search>) => payload,
   'api.success': (payload: ApiSuccessResponse<DataType>) => payload,
   'api.error': (payload: { error: string }) => payload,
 });
 
-export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
-  service: ApiCallback<RawDataType, QueryType>,
+export function makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
+  service: ApiCallback<RawDataType, OrderBy, Search>,
   dataTransformer: (response: RawDataType) => DataType,
   options?: {
     pollingEnabled?: boolean;
@@ -74,10 +77,15 @@ export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
       pollingEnabled: options?.pollingEnabled || false,
       onBeforeSetResponse: options?.onBeforeSetResponse,
       dataTransformer,
-    } as PaginatedMachineContext<RawDataType, QueryType, DataType>,
+    } as PaginatedMachineContext<RawDataType, OrderBy, Search, DataType>,
     {
       events: {
-        ...getPaginatedApiMachineEvents<RawDataType, QueryType, DataType>(),
+        ...getPaginatedApiMachineEvents<
+          RawDataType,
+          OrderBy,
+          Search,
+          DataType
+        >(),
       },
       actions: {
         notifyReady: () => ({}),
@@ -135,18 +143,20 @@ export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
     };
   }, 'api.prevPage');
   const query = model.assign((context, event) => {
-    const { page, size, query } = event;
+    const { page, size, search: query } = event;
     return {
       request: {
         page: page || context.request.page,
         size: size || context.request.size,
-        query,
+        search: query,
       },
     };
   }, 'api.query');
 
   const callApi =
-    (context: PaginatedMachineContext<RawDataType, QueryType, DataType>) =>
+    (
+      context: PaginatedMachineContext<RawDataType, OrderBy, Search, DataType>
+    ) =>
     (callback: Sender<any>) => {
       return service(
         context.request!,
@@ -353,11 +363,11 @@ export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
             Math.ceil(context.response.total / context.request.size),
         isTotalZero: (context) => context.response?.total === 0,
         isQuerySuccesful: (context) =>
-          context.request.query !== undefined &&
+          context.request.search !== undefined &&
           context.response !== undefined &&
           context.response?.total > 0,
         isQueryEmpty: (context) =>
-          context.request.query !== undefined &&
+          context.request.search !== undefined &&
           context.response !== undefined &&
           context.response?.total === 0,
         isPollingEnabled: (context) => context.pollingEnabled,
@@ -367,27 +377,27 @@ export function makePaginatedApiMachine<RawDataType, QueryType, DataType>(
 }
 
 // https://stackoverflow.com/questions/50321419/typescript-returntype-of-generic-function/64919133#64919133
-class Wrapper<RawDataType, QueryType, DataType> {
+class Wrapper<RawDataType, OrderBy, Search, DataType> {
   wrapped(
-    service: ApiCallback<RawDataType, QueryType>,
+    service: ApiCallback<RawDataType, OrderBy, Search>,
     dataTransformer: (response: RawDataType) => DataType
   ) {
-    return makePaginatedApiMachine<RawDataType, QueryType, DataType>(
+    return makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
       service,
       dataTransformer
     );
   }
 }
 
-export type PaginatedApiActorType<RawDataType, QueryType, DataType> =
+export type PaginatedApiActorType<RawDataType, OrderBy, Search, DataType> =
   ActorRefFrom<
-    ReturnType<Wrapper<RawDataType, QueryType, DataType>['wrapped']>
+    ReturnType<Wrapper<RawDataType, OrderBy, Search, DataType>['wrapped']>
   >;
 
 // These are not _writable_ booleans, they are derived from the machine state!
 // https://discord.com/channels/795785288994652170/799416943324823592/847466843290730527
-export type usePaginationReturnValue<QueryType, DataType> = {
-  request: PaginatedApiRequest<QueryType>;
+export type usePaginationReturnValue<OrderBy, Search, DataType> = {
+  request: PaginatedApiRequest<OrderBy, Search>;
   response?: PaginatedApiResponse<DataType>;
   loading: boolean;
   queryEmpty: boolean;
@@ -397,15 +407,15 @@ export type usePaginationReturnValue<QueryType, DataType> = {
   error: boolean;
   firstRequest: boolean;
 };
-export const usePagination = <RawDataType, QueryType, DataType>(
-  actor: PaginatedApiActorType<RawDataType, QueryType, DataType>
-): usePaginationReturnValue<QueryType, DataType> => {
+export const usePagination = <RawDataType, OrderBy, Search, DataType>(
+  actor: PaginatedApiActorType<RawDataType, OrderBy, Search, DataType>
+): usePaginationReturnValue<OrderBy, Search, DataType> => {
   return useSelector(
     actor,
     useCallback(
       (
         state: typeof actor.state
-      ): usePaginationReturnValue<QueryType, DataType> => {
+      ): usePaginationReturnValue<OrderBy, Search, DataType> => {
         return {
           request: state.context.request,
           response: state.context.response,

--- a/src/app/machines/StepConnectorTypes.machine.ts
+++ b/src/app/machines/StepConnectorTypes.machine.ts
@@ -19,6 +19,8 @@ import {
   makePaginatedApiMachine,
 } from './PaginatedResponse.machine';
 
+export const DEFAULT_CONNECTOR_TYPES_PAGE_SIZE = 20;
+
 type Context = {
   accessToken: () => Promise<string>;
   connectorsApiBasePath: string;
@@ -96,7 +98,9 @@ export const connectorTypesMachine = model.createMachine(
                   ConnectorTypesOrderBy,
                   ConnectorTypesSearch,
                   ConnectorType
-                >(fetchConnectorTypes(context), (i) => i),
+                >(fetchConnectorTypes(context), (i) => i, {
+                  initialPageSize: DEFAULT_CONNECTOR_TYPES_PAGE_SIZE,
+                }),
             },
             states: {
               idle: {

--- a/src/app/machines/StepConnectorTypes.machine.ts
+++ b/src/app/machines/StepConnectorTypes.machine.ts
@@ -1,4 +1,8 @@
-import { ConnectorTypesQuery, fetchConnectorTypes } from '@apis/api';
+import {
+  ConnectorTypesOrderBy,
+  ConnectorTypesSearch,
+  fetchConnectorTypes,
+} from '@apis/api';
 import { PAGINATED_MACHINE_ID } from '@constants/constants';
 
 import { ActorRefFrom, send, sendParent } from 'xstate';
@@ -42,7 +46,8 @@ const model = createModel(
       confirm: () => ({}),
       ...getPaginatedApiMachineEvents<
         ConnectorType,
-        ConnectorTypesQuery,
+        ConnectorTypesOrderBy,
+        ConnectorTypesSearch,
         ConnectorType
       >(),
     },
@@ -88,7 +93,8 @@ export const connectorTypesMachine = model.createMachine(
               src: (context) =>
                 makePaginatedApiMachine<
                   ConnectorType,
-                  ConnectorTypesQuery,
+                  ConnectorTypesOrderBy,
+                  ConnectorTypesSearch,
                   ConnectorType
                 >(fetchConnectorTypes(context), (i) => i),
             },

--- a/src/app/machines/StepKafkas.machine.ts
+++ b/src/app/machines/StepKafkas.machine.ts
@@ -1,4 +1,4 @@
-import { KafkasQuery, fetchKafkaInstances } from '@apis/api';
+import { KafkasSearch, fetchKafkaInstances } from '@apis/api';
 import { PAGINATED_MACHINE_ID } from '@constants/constants';
 
 import { ActorRefFrom, send } from 'xstate';
@@ -12,6 +12,7 @@ import {
   getPaginatedApiMachineEvents,
   makePaginatedApiMachine,
   PaginatedApiResponse,
+  PlaceholderOrderBy,
 } from './PaginatedResponse.machine';
 
 type Context = {
@@ -41,7 +42,8 @@ const model = createModel(
       confirm: () => ({}),
       ...getPaginatedApiMachineEvents<
         KafkaRequest,
-        KafkasQuery,
+        PlaceholderOrderBy,
+        KafkasSearch,
         KafkaRequest
       >(),
     },
@@ -87,7 +89,8 @@ export const kafkasMachine = model.createMachine(
               src: (context) =>
                 makePaginatedApiMachine<
                   KafkaRequest,
-                  KafkasQuery,
+                  PlaceholderOrderBy,
+                  KafkasSearch,
                   KafkaRequest
                 >(fetchKafkaInstances(context), (i) => i),
             },

--- a/src/app/machines/StepNamespace.machine.ts
+++ b/src/app/machines/StepNamespace.machine.ts
@@ -10,6 +10,8 @@ import {
   ApiSuccessResponse,
   getPaginatedApiMachineEvents,
   makePaginatedApiMachine,
+  PlaceholderOrderBy,
+  PlaceholderSearch,
 } from './PaginatedResponse.machine';
 
 type Context = {
@@ -37,7 +39,8 @@ const model = createModel(
       confirm: () => ({}),
       ...getPaginatedApiMachineEvents<
         ConnectorNamespace,
-        {},
+        PlaceholderOrderBy,
+        PlaceholderSearch,
         ConnectorNamespace
       >(),
     },
@@ -83,7 +86,8 @@ export const namespacesMachine = model.createMachine(
               src: (context) =>
                 makePaginatedApiMachine<
                   ConnectorNamespace,
-                  {},
+                  PlaceholderOrderBy,
+                  PlaceholderSearch,
                   ConnectorNamespace
                 >(fetchConnectorNamespaces(context), (i) => i, {
                   pollingEnabled: true,

--- a/src/app/pages/ConnectorsPage/ConnectorsPage.tsx
+++ b/src/app/pages/ConnectorsPage/ConnectorsPage.tsx
@@ -121,7 +121,7 @@ export const ConnectorsPageBody: FunctionComponent<ConnectorsPageBodyProps> = ({
     response,
     selectedConnector,
     deselectConnector,
-    query,
+    runQuery,
   } = useConnectorsMachine();
 
   const currentConnectorRef = response?.items?.filter((ref) => {
@@ -134,7 +134,7 @@ export const ConnectorsPageBody: FunctionComponent<ConnectorsPageBodyProps> = ({
     case queryEmpty:
       return (
         <EmptyStateNoMatchesFound
-          onClear={() => query({ page: 1, size: 10 })}
+          onClear={() => runQuery({ page: 1, size: 10 })}
         />
       );
     case loading:
@@ -149,7 +149,7 @@ export const ConnectorsPageBody: FunctionComponent<ConnectorsPageBodyProps> = ({
                 itemCount={response?.total || 0}
                 page={request.page}
                 perPage={request.size}
-                onChange={(page, size) => query({ page, size })}
+                onChange={runQuery}
               />
               <Loading />
             </Card>
@@ -208,7 +208,7 @@ export const ConnectedTable: FunctionComponent<ConnectorsTableProps> = ({
   onConnectorDetail,
   onDuplicateConnector,
 }) => {
-  const { request, response, selectedConnector, query } =
+  const { request, response, selectedConnector, runQuery } =
     useConnectorsMachine();
   return (
     <Card className={'pf-u-pb-xl'}>
@@ -216,7 +216,9 @@ export const ConnectedTable: FunctionComponent<ConnectorsTableProps> = ({
         itemCount={response?.total || 0}
         page={request.page}
         perPage={request.size}
-        onChange={(page, size) => query({ page, size })}
+        search={request.search}
+        orderBy={request.orderBy}
+        onChange={runQuery}
       />
       <div className={'pf-u-p-md'}>
         <ConnectorsTable>
@@ -235,7 +237,13 @@ export const ConnectedTable: FunctionComponent<ConnectorsTableProps> = ({
         itemCount={response?.total || 0}
         page={request.page}
         perPage={request.size}
-        onChange={(page, size) => query({ page, size })}
+        onChange={(event) =>
+          runQuery({
+            ...event,
+            orderBy: request.orderBy,
+            search: request.search,
+          })
+        }
         isCompact={false}
       />
     </Card>

--- a/src/app/pages/ConnectorsPage/ConnectorsPageContext.tsx
+++ b/src/app/pages/ConnectorsPage/ConnectorsPageContext.tsx
@@ -1,3 +1,4 @@
+import { ConnectorsOrderBy, ConnectorsSearch } from '@apis/api';
 import { ConnectorMachineActorRef } from '@app/machines/Connector.machine';
 import {
   connectorsPageMachine,
@@ -67,21 +68,30 @@ export const useConnectorsPageIsReady = () => {
 };
 
 type useConnectorsMachineReturnType = usePaginationReturnValue<
-  {},
+  ConnectorsOrderBy,
+  ConnectorsSearch,
   ConnectorMachineActorRef
 > & {
   selectedConnector: Connector | undefined;
   deselectConnector: () => void;
-  query: (props: PaginatedApiRequest<{}>) => void;
+  runQuery: (
+    props: PaginatedApiRequest<ConnectorsOrderBy, ConnectorsSearch>
+  ) => void;
 };
 
 export const useConnectorsMachine = (): useConnectorsMachineReturnType => {
   const service = useConnectorsPageMachineService();
 
-  const apiData = usePagination<Connector, {}, ConnectorMachineActorRef>(
+  const apiData = usePagination<
+    Connector,
+    ConnectorsOrderBy,
+    ConnectorsSearch,
+    ConnectorMachineActorRef
+  >(
     service.state.children[PAGINATED_MACHINE_ID] as PaginatedApiActorType<
       Connector,
-      {},
+      ConnectorsOrderBy,
+      ConnectorsSearch,
       ConnectorMachineActorRef
     >
   );
@@ -99,8 +109,8 @@ export const useConnectorsMachine = (): useConnectorsMachineReturnType => {
     service.send({ type: 'deselectConnector' });
   }, [service]);
 
-  const query = useCallback(
-    (props: PaginatedApiRequest<{}>) => {
+  const runQuery = useCallback(
+    (props: PaginatedApiRequest<ConnectorsOrderBy, ConnectorsSearch>) => {
       service.send({ type: 'api.query', ...props });
     },
     [service]
@@ -110,6 +120,6 @@ export const useConnectorsMachine = (): useConnectorsMachineReturnType => {
     ...apiData,
     selectedConnector,
     deselectConnector,
-    query,
+    runQuery,
   };
 };

--- a/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConnectorTypes.tsx
@@ -11,6 +11,7 @@ import {
   PaginationEvent,
 } from '@app/components/Pagination/Pagination';
 import { StepBodyLayout } from '@app/components/StepBodyLayout/StepBodyLayout';
+import { DEFAULT_CONNECTOR_TYPES_PAGE_SIZE } from '@app/machines/StepConnectorTypes.machine';
 import React, {
   FunctionComponent,
   useCallback,
@@ -92,7 +93,7 @@ export function ConnectorTypesGallery() {
                   onClear={() =>
                     runQuery({
                       page: 1,
-                      size: 10,
+                      size: DEFAULT_CONNECTOR_TYPES_PAGE_SIZE,
                       search: undefined,
                     })
                   }
@@ -216,6 +217,7 @@ export function ConnectorTypesGallery() {
                       })}
                     </Gallery>
                   )}
+                  <ConnectorTypesPagination onChange={runQuery} />
                 </div>
               </>
             );
@@ -400,7 +402,13 @@ const ConnectorTypesPagination: FunctionComponent<ConnectorTypesPaginationProps>
         itemCount={response?.total || 0}
         page={request.page}
         perPage={request.size}
-        onChange={onChange}
+        onChange={(event) => {
+          onChange({
+            ...event,
+            orderBy: request.orderBy,
+            search: request.search,
+          });
+        }}
         isCompact={isCompact}
       />
     );

--- a/src/app/pages/CreateConnectorPage/StepKafkas.tsx
+++ b/src/app/pages/CreateConnectorPage/StepKafkas.tsx
@@ -73,7 +73,7 @@ const KafkasGallery: FunctionComponent = () => {
     // queryResults,
     firstRequest,
     onSelect,
-    onQuery,
+    runQuery,
   } = useKafkasMachine();
 
   useEffect(() => {
@@ -102,7 +102,7 @@ const KafkasGallery: FunctionComponent = () => {
               <>
                 <KafkaToolbar />
                 <EmptyStateNoMatchesFound
-                  onClear={() => onQuery({ page: 1, size: 10 })}
+                  onClear={() => runQuery({ page: 1, size: 10 })}
                 />
               </>
             );
@@ -186,7 +186,7 @@ const KafkasGallery: FunctionComponent = () => {
 const KafkaToolbar: FunctionComponent = () => {
   const { t } = useTranslation();
 
-  const { request, onQuery } = useKafkasMachine();
+  const { request, runQuery } = useKafkasMachine();
 
   const [statusesToggled, setStatusesToggled] = useState(false);
   const [cloudProvidersToggled, setCloudProvidersToggled] = useState(false);
@@ -210,7 +210,7 @@ const KafkaToolbar: FunctionComponent = () => {
     []
   );
 
-  const debouncedOnQuery = useDebounce(onQuery, 1000);
+  const debouncedOnQuery = useDebounce(runQuery, 1000);
 
   const {
     name,
@@ -218,21 +218,21 @@ const KafkaToolbar: FunctionComponent = () => {
     cloudProviders = [],
     regions = [],
     statuses = [],
-  } = request.query || {};
+  } = request.search || {};
 
   const clearAllFilters = useCallback(
-    () => onQuery({ page: 1, size: request.size }),
-    [onQuery, request.size]
+    () => runQuery({ page: 1, size: request.size }),
+    [runQuery, request.size]
   );
 
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const ownerInputRef = useRef<HTMLInputElement | null>(null);
 
   const onSelectFilter = (category: string, values: string[], value: string) =>
-    onQuery({
+    runQuery({
       ...request,
-      query: {
-        ...(request.query || {}),
+      search: {
+        ...(request.search || {}),
         [category]: values.includes(value)
           ? values.filter((s) => s !== value)
           : [...(values || []), value],
@@ -265,10 +265,10 @@ const KafkaToolbar: FunctionComponent = () => {
   };
 
   const onDeleteQueryGroup = (category: string) =>
-    onQuery({
+    runQuery({
       ...request,
-      query: {
-        ...(request.query || {}),
+      search: {
+        ...(request.search || {}),
         [category]: undefined,
       },
     });
@@ -425,8 +425,9 @@ const KafkaToolbar: FunctionComponent = () => {
                     debouncedOnQuery({
                       size: request.size,
                       page: 1,
-                      query: {
-                        ...request.query,
+                      orderBy: request.orderBy,
+                      search: {
+                        ...request.search,
                         name,
                       },
                     })
@@ -437,11 +438,12 @@ const KafkaToolbar: FunctionComponent = () => {
                   variant={'control'}
                   aria-label="search button for name input"
                   onClick={() =>
-                    onQuery({
+                    runQuery({
                       size: request.size,
                       page: 1,
-                      query: {
-                        ...request.query,
+                      orderBy: request.orderBy,
+                      search: {
+                        ...request.search,
                         name: nameInputRef.current?.value || '',
                       },
                     })
@@ -472,8 +474,9 @@ const KafkaToolbar: FunctionComponent = () => {
                     debouncedOnQuery({
                       size: request.size,
                       page: 1,
-                      query: {
-                        ...request.query,
+                      orderBy: request.orderBy,
+                      search: {
+                        ...request.search,
                         owner,
                       },
                     })
@@ -484,11 +487,12 @@ const KafkaToolbar: FunctionComponent = () => {
                   variant={'control'}
                   aria-label="search button for owner input"
                   onClick={() =>
-                    onQuery({
+                    runQuery({
                       size: request.size,
                       page: 1,
-                      query: {
-                        ...request.query,
+                      orderBy: request.orderBy,
+                      search: {
+                        ...request.search,
                         owner: ownerInputRef.current?.value || '',
                       },
                     })
@@ -581,14 +585,16 @@ type KafkasPaginationProps = {
 const KafkasPagination: FunctionComponent<KafkasPaginationProps> = ({
   isCompact = false,
 }) => {
-  const { request, response, onQuery } = useKafkasMachine();
+  const { request, response, runQuery } = useKafkasMachine();
 
   return (
     <Pagination
       itemCount={response?.total || 0}
       page={request.page}
       perPage={request.size}
-      onChange={(page, size) => onQuery({ page, size })}
+      onChange={(event) =>
+        runQuery({ ...event, orderBy: request.orderBy, search: request.search })
+      }
       isCompact={isCompact}
     />
   );

--- a/src/app/pages/CreateConnectorPage/StepNamespace.tsx
+++ b/src/app/pages/CreateConnectorPage/StepNamespace.tsx
@@ -77,7 +77,7 @@ const ClustersGallery: FunctionComponent = () => {
     onSelect,
     onDeselect,
     onRefresh,
-    onQuery,
+    runQuery: onQuery,
   } = useNamespaceMachine();
   const onModalToggle = useCallback(() => {
     setIsModalOpen((prev) => !prev);
@@ -306,10 +306,10 @@ const ClustersToolbar: FunctionComponent<ClustersToolbarProps> = ({
   isEvalPresent,
 }) => {
   // const { t } = useTranslation();
-  const { request, onQuery } = useNamespaceMachine();
+  const { request, runQuery } = useNamespaceMachine();
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const debouncedOnQuery = useDebounce(onQuery, 1000);
+  const debouncedOnQuery = useDebounce(runQuery, 1000);
 
   // const [statuses, setStatuses] = useState<string[]>([
   //   'Pending',
@@ -361,7 +361,9 @@ const ClustersToolbar: FunctionComponent<ClustersToolbarProps> = ({
               debouncedOnQuery({
                 size: request.size,
                 page: 1,
-                name: value,
+                search: {
+                  name: value,
+                },
               })
             }
             ref={searchInputRef}
@@ -446,13 +448,15 @@ type ClustersPaginationProps = {
 const ClustersPagination: FunctionComponent<ClustersPaginationProps> = ({
   isCompact = false,
 }) => {
-  const { request, response, onQuery } = useNamespaceMachine();
+  const { request, response, runQuery } = useNamespaceMachine();
   return (
     <Pagination
       itemCount={response?.total || 0}
       page={request.page}
       perPage={request.size}
-      onChange={(page, size) => onQuery({ page, size })}
+      onChange={(event) =>
+        runQuery({ ...event, orderBy: request.orderBy, search: request.search })
+      }
       isCompact={isCompact}
     />
   );


### PR DESCRIPTION
This change updates the pagination utility classes to add support for
orderBy and aligns the filtering support to better match the API.  This
change also updates the pagination usage a little bit across the
toolbars in the application.  Finally this change also brings back the
search filter on the connectors instance list.  Further work is needed
to add sorting controls as well as additional filter categories for the
connectors instance list search.