### PR TITLE
MGDCTRS-967 fix: add padding to the page bottom

### DIFF
--- a/src/app/components/Pagination/Pagination.css
+++ b/src/app/components/Pagination/Pagination.css
@@ -1,0 +1,4 @@
+.cos-ui-pagination.pf-m-bottom {
+  padding-bottom: 3em;
+  background: inherit;
+}

--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 
 import { Pagination as PFPagination } from '@patternfly/react-core';
 
+import './Pagination.css';
+
 export type PaginationEvent<OrderBy, Search> = {
   page: number;
   size: number;
@@ -49,6 +51,7 @@ export const Pagination: FunctionComponent<PaginationProps<object, object>> = ({
   ];
   return (
     <PFPagination
+      className={'cos-ui-pagination'}
       itemCount={itemCount}
       page={page}
       perPage={perPage}


### PR DESCRIPTION
This change adds some padding to the bottom of the lower pagination
control to ensure it occupies enough page space so that it isn't
overlapped by the resource icon.  This change also corrects a visual bug
on the connector type selection page.

![Screenshot from 2022-07-12 15-23-54](https://user-images.githubusercontent.com/351660/178578301-82b4d83d-0954-499f-94a5-0c983260d02f.png)

and also (the drop shadow on the bottom card was being hidden):

![Screenshot from 2022-07-12 15-31-21](https://user-images.githubusercontent.com/351660/178578484-8f9e741a-9e65-4845-96da-f3ca87d15f8e.png)

