### PR TITLE
MGDCTRS-1149:chore: update SA fields in edit connector flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 #stage
-BASE_PATH=https://wxn4aqqc8bqvxcy6unfe.api.stage.openshift.com
+#BASE_PATH=https://wxn4aqqc8bqvxcy6unfe.api.stage.openshift.com
 #dev
-#BASE_PATH=https://cos-fleet-manager-managed-connectors-dev.rhoc-dev-153f1de160110098c1928a6c05e19444-0000.eu-de.containers.appdomain.cloud
+BASE_PATH=https://cos-fleet-manager-managed-connectors-dev.rhoc-dev-153f1de160110098c1928a6c05e19444-0000.eu-de.containers.appdomain.cloud
 #BASE_PATH=http://localhost:8000

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
@@ -180,9 +180,6 @@ export const ConfigurationTab: FC<ConfigurationTabProps> = ({
 
   const initialize = () => {
     const { name, service_account } = connectorData;
-    service_account.client_secret === ''
-      ? (service_account.client_secret = '*****')
-      : service_account.client_secret;
     setCommonConfiguration({ name: name, service_account: service_account });
     setConnectorConfiguration(connectorData?.connector);
     setErrHandlerConfiguration(

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
@@ -180,6 +180,9 @@ export const ConfigurationTab: FC<ConfigurationTabProps> = ({
 
   const initialize = () => {
     const { name, service_account } = connectorData;
+    service_account.client_secret === ''
+      ? (service_account.client_secret = '*****')
+      : service_account.client_secret;
     setCommonConfiguration({ name: name, service_account: service_account });
     setConnectorConfiguration(connectorData?.connector);
     setErrHandlerConfiguration(

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
@@ -194,7 +194,6 @@ export const CommonStep: FC<CommonStepProp> = ({
           )}
         </FormGroup>
         {editMode &&
-          isSAUpdate &&
           service_account?.client_secret === '' &&
           SAPlaceholder !== '' && (
             <SecretPlaceholder

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
@@ -203,7 +203,7 @@ export const CommonStep: FC<CommonStepProp> = ({
             />
           )}
 
-        {SAPlaceholder === '' && (
+        {editMode && SAPlaceholder === '' && (
           <FormGroup
             label={t('clientSecret')}
             isRequired

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab/CommonStep.tsx
@@ -37,44 +37,59 @@ export const CommonStep: FC<CommonStepProp> = ({
 
   const [isSAUpdate, setIsSAUpdate] = React.useState(false);
   const [passwordHidden, setPasswordHidden] = React.useState<boolean>(true);
-
+  const [showEyeIcon, setShowEyeIcon] = React.useState<boolean>(false);
   const onNameChange = (val: any) => {
     onUpdateConfiguration('common', { ...configuration, name: val });
     val === '' ? changeIsValid(false) : changeIsValid(true);
   };
 
-  const onSAChange = (
-    val: string,
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    if (event.currentTarget.id === 'connector-sa-id') {
-      onUpdateConfiguration('common', {
-        ...configuration,
-        service_account: {
-          client_id: val,
-          client_secret: configuration.service_account.client_secret,
-        },
+  const onSAChange = (clientId: string) => {
+    onUpdateConfiguration('common', {
+      ...configuration,
+      service_account: {
+        client_id: clientId,
+        client_secret: configuration.service_account.client_secret,
+      },
+    });
+    !isSAUpdate &&
+      setIsSAUpdate((prev) => {
+        if (!prev) {
+          changeIsValid(false);
+        }
+        return true;
       });
-      !isSAUpdate &&
-        setIsSAUpdate((prev) => {
-          if (!prev) {
-            changeIsValid(false);
-          }
-          return true;
-        });
-    } else {
-      onUpdateConfiguration('common', {
-        ...configuration,
-        service_account: {
-          client_id: configuration.service_account.client_id,
-          client_secret: val,
-        },
-      });
-    }
 
-    val === '' ? changeIsValid(false) : changeIsValid(true);
+    if (
+      configuration.service_account.client_secret.includes('*') ||
+      clientId === ''
+    ) {
+      setShowEyeIcon(false);
+      changeIsValid(false);
+    } else {
+      setShowEyeIcon(true);
+      changeIsValid(true);
+    }
   };
 
+  const onSASecretChange = (secret: string) => {
+    onUpdateConfiguration('common', {
+      ...configuration,
+      service_account: {
+        client_id: configuration.service_account.client_id,
+        client_secret: secret,
+      },
+    });
+    if (
+      configuration.service_account.client_secret.includes('*') ||
+      secret === ''
+    ) {
+      setShowEyeIcon(false);
+      changeIsValid(false);
+    } else {
+      setShowEyeIcon(true);
+      changeIsValid(true);
+    }
+  };
   return (
     <StepBodyLayout title={t('core')} description={t('basicStepDescription')}>
       <Form>
@@ -162,6 +177,7 @@ export const CommonStep: FC<CommonStepProp> = ({
                 ? 'default'
                 : 'error'
             }
+            helperText={t('credentialEditFieldHelpText')}
             helperTextInvalid={t('clientSecretRequired')}
             helperTextInvalidIcon={<ExclamationCircleIcon />}
             fieldId="clientSecret"
@@ -175,16 +191,20 @@ export const CommonStep: FC<CommonStepProp> = ({
                     ? 'default'
                     : 'error'
                 }
-                onChange={onSAChange}
+                onChange={onSASecretChange}
                 id="connector-sa-secret"
               />
-              <Button
-                variant="control"
-                onClick={() => setPasswordHidden(!passwordHidden)}
-                aria-label={passwordHidden ? 'Show password' : 'Hide password'}
-              >
-                {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-              </Button>
+              {showEyeIcon && (
+                <Button
+                  variant="control"
+                  onClick={() => setPasswordHidden(!passwordHidden)}
+                  aria-label={
+                    passwordHidden ? 'Show password' : 'Hide password'
+                  }
+                >
+                  {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                </Button>
+              )}
             </InputGroup>
           </FormGroup>
         ) : (


### PR DESCRIPTION
This PR updates SA fields in the edit connector flow. Added helper text to the Client Secret field. 
When you edit SA Client Id It displays the Client Secret field with 5 pre-field bullet points. Once you update the secret field with a new value you can see the EyeIcon which shows/hide entered value. It also validates the empty values