### PR TITLE
MGDCTRS-1067: fix: Improve the KI shown in overview and drawer

### DIFF
--- a/cypress/integration/connectors.spec.ts
+++ b/cypress/integration/connectors.spec.ts
@@ -61,7 +61,7 @@ describe('Connectors page', () => {
     cy.findByText(
       'view more'
     ).should('exist');
-    cy.findByLabelText('Close drawer panel').click();
+    cy.findByLabelText('Close drawer panel').click({force: true});
     cy.findByText('Connector name').should('not.exist');
 
     // should open the actions dropdown

--- a/cypress/integration/connectors.spec.ts
+++ b/cypress/integration/connectors.spec.ts
@@ -72,7 +72,7 @@ describe('Connectors page', () => {
     cy.findByText(
       'lb-cos--vgitqo-mk-imjg-eyqfbazqdiv.bf2.kafka.rhcloud.com:443'
     ).should('exist');
-    cy.findByLabelText('Close drawer panel').click();
+    cy.findByLabelText('Close drawer panel').click({force: true});
   });
 
   it('allows actions to be triggered', () => {

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -94,6 +94,7 @@
   "gettingStartedQuickstart": "getting-started-connectors",
   "id": "id",
   "kafkaInstance": "Kafka Instance",
+  "KafkaInstanceExpired" : "Kafka instance no longer exists",
   "kafkaStepDescription": "The selected OpenShift Streams for Apache Kafka instance works with your Connectors instance. A source connector ingests data from another system into a Kafka instance. A sink connector propagates data from a Kafka instance into another system.",
   "leave": "Leave",
   "leaveCreateConnectorConfirmModalDescription": "Changes you have made will be lost and no connector will be created.",

--- a/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.css
+++ b/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.css
@@ -1,3 +1,6 @@
 .my-class > h4 {
   margin-top: 0px;
 }
+.Kafka-link-button {
+  padding: 0px;
+}

--- a/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
+++ b/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
@@ -4,13 +4,17 @@ import { useTranslation } from 'react-i18next';
 import {
   Alert,
   Button,
+  Text,
   TextContent,
   TextList,
   TextListItem,
   TextListItemVariants,
   TextListVariants,
+  TextVariants,
 } from '@patternfly/react-core';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
+
+import { KafkaInstance } from '@rhoas/app-services-ui-shared';
 
 import './ConnectorInfoTextList.css';
 
@@ -21,9 +25,9 @@ export type ConnectorInfoTextListProps = {
   id: string;
   type?: string;
   bootstrapServer: string;
-  kafkaId: string;
+  kafkaId: string | KafkaInstance | ReactNode;
   owner: string;
-  namespaceId: string;
+  namespaceId: string | ReactNode;
   namespaceMsg?: string | undefined;
   namespaceMsgVariant: AlertType;
   createdAt: Date;
@@ -67,7 +71,10 @@ export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps
       }
       return value;
     };
-    const textListItem = (title: string, value?: ReactNode) => (
+    const textListItem = (
+      title: string,
+      value?: string | KafkaInstance | ReactNode
+    ) => (
       <>
         {value && (
           <>
@@ -75,9 +82,39 @@ export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps
               {title}
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {title === t('failureReason')
-                ? getFailureReason(value as string)
-                : value}
+              {(() => {
+                switch (title) {
+                  case t('failureReason'):
+                    return getFailureReason(value as string);
+                  case t('kafkaInstance'):
+                    return (value as KafkaInstance)?.name ? (
+                      <Button
+                        className="Kafka-link-button"
+                        variant="link"
+                        onClick={() => {
+                          window.open(
+                            'https://console.redhat.com/application-services/streams/kafkas/' +
+                              (value as KafkaInstance).id,
+                            '_blank'
+                          );
+                        }}
+                      >
+                        {(value as KafkaInstance).name}
+                      </Button>
+                    ) : typeof value === 'string' ? (
+                      <Text
+                        component={TextVariants.p}
+                        className="pf-u-color-400"
+                      >
+                        {value}
+                      </Text>
+                    ) : (
+                      value
+                    );
+                  default:
+                    return value;
+                }
+              })()}
             </TextListItem>
           </>
         )}

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -10,6 +10,7 @@ import '@patternfly/patternfly/utilities/Display/display.css';
 import '@patternfly/patternfly/utilities/Flex/flex.css';
 import '@patternfly/patternfly/utilities/Sizing/sizing.css';
 import '@patternfly/patternfly/utilities/Spacing/spacing.css';
+import '@patternfly/patternfly/utilities/Text/text.css';
 
 import { AppDemo } from './AppDemo';
 import { AppE2E } from './AppE2E';


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/MGDCTRS-1067

- Show the KI name in place of the id
- Clickable KI name to open KI in use in the new tab
- MSG for expired KI
- Show loader when KI and Namespace call is being made


![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/8264372/181053200-cb195eb7-0f35-409c-88be-b8ef44cdcd30.gif)


