### PR TITLE
MGDCTRS-1189: feat:Add option to duplicate a connector for expired KI

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -94,7 +94,7 @@
   "gettingStartedQuickstart": "getting-started-connectors",
   "id": "id",
   "kafkaInstance": "Kafka Instance",
-  "KafkaInstanceExpired" : "Kafka instance no longer exists",
+  "KafkaInstanceExpired" : "No longer exists",
   "kafkaStepDescription": "The selected OpenShift Streams for Apache Kafka instance works with your Connectors instance. A source connector ingests data from another system into a Kafka instance. A sink connector propagates data from a Kafka instance into another system.",
   "leave": "Leave",
   "leaveCreateConnectorConfirmModalDescription": "Changes you have made will be lost and no connector will be created.",

--- a/src/CosRoutes.tsx
+++ b/src/CosRoutes.tsx
@@ -85,7 +85,10 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
           />
         </Route>
         <Route path={'/:id/'}>
-          <ConnectorDetailsPage onSave={goToConnectorsList} />
+          <ConnectorDetailsPage
+            onSave={goToConnectorsList}
+            onDuplicateConnector={goToDuplicateConnector}
+          />
         </Route>
       </Switch>
     </CosContextProvider>

--- a/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
+++ b/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
@@ -304,6 +304,7 @@ export const ConnectorDrawerPanelContent: FunctionComponent<ConnectorDrawerPanel
 
               <div className="connector-drawer__tab-content">
                 <ConnectorInfoTextList
+                  onDuplicateConnector={onDuplicateConnector}
                   name={name}
                   id={id}
                   bootstrapServer={bootstrapServer}

--- a/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
+++ b/src/app/components/ConnectorInfoTextList/ConnectorInfoTextList.tsx
@@ -33,6 +33,7 @@ export type ConnectorInfoTextListProps = {
   createdAt: Date;
   modifiedAt: Date;
   error?: string;
+  onDuplicateConnector: (id: string) => void;
 };
 
 export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps> =
@@ -49,6 +50,7 @@ export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps
     createdAt,
     modifiedAt,
     error,
+    onDuplicateConnector,
   }) => {
     const { t } = useTranslation();
     const [failureReasonExpand, setFailureReasonExpand] = React.useState(false);
@@ -102,12 +104,21 @@ export const ConnectorInfoTextList: FunctionComponent<ConnectorInfoTextListProps
                         {(value as KafkaInstance).name}
                       </Button>
                     ) : typeof value === 'string' ? (
-                      <Text
-                        component={TextVariants.p}
-                        className="pf-u-color-400"
-                      >
-                        {value}
-                      </Text>
+                      <>
+                        <Text
+                          component={TextVariants.p}
+                          className="pf-u-color-400"
+                        >
+                          {value}
+                        </Text>
+                        <Button
+                          className="Kafka-link-button"
+                          variant="link"
+                          onClick={() => onDuplicateConnector(id)}
+                        >
+                          {t('duplicateConnector')}
+                        </Button>
+                      </>
                     ) : (
                       value
                     );

--- a/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
@@ -38,10 +38,12 @@ const getTab = (hash: string): string => {
 
 type ConnectorDetailsPageProps = {
   onSave: () => void;
+  onDuplicateConnector: (id: string) => void;
 };
 
 export const ConnectorDetailsPage: FC<ConnectorDetailsPageProps> = ({
   onSave,
+  onDuplicateConnector,
 }) => {
   let { id } = useParams<ParamTypes>();
   let { hash } = useLocation();
@@ -148,7 +150,10 @@ export const ConnectorDetailsPage: FC<ConnectorDetailsPageProps> = ({
                 eventKey={CONNECTOR_DETAILS_TABS.Overview}
                 title={<TabTitleText>{t('overview')}</TabTitleText>}
               >
-                <OverviewTab connectorData={connectorData} />
+                <OverviewTab
+                  connectorData={connectorData}
+                  onDuplicateConnector={onDuplicateConnector}
+                />
               </Tab>
               <Tab
                 eventKey={CONNECTOR_DETAILS_TABS.Configuration}

--- a/src/app/pages/ConnectorDetailsPage/OverviewTab.tsx
+++ b/src/app/pages/ConnectorDetailsPage/OverviewTab.tsx
@@ -22,9 +22,13 @@ import { Connector, ConnectorNamespace } from '@rhoas/connector-management-sdk';
 
 export interface OverviewTabProps {
   connectorData: Connector;
+  onDuplicateConnector: (id: string) => void;
 }
 
-export const OverviewTab: FC<OverviewTabProps> = ({ connectorData }) => {
+export const OverviewTab: FC<OverviewTabProps> = ({
+  connectorData,
+  onDuplicateConnector,
+}) => {
   const [namespaceData, setNamespaceData] = useState<ConnectorNamespace>();
   const [KIData, setKIData] = useState<KafkaInstance | string>();
 
@@ -131,6 +135,7 @@ export const OverviewTab: FC<OverviewTabProps> = ({ connectorData }) => {
       )}
 
       <ConnectorInfoTextList
+        onDuplicateConnector={onDuplicateConnector}
         name={connectorData?.name}
         id={connectorData?.id!}
         type={connectorData?.connector_type_id}


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/MGDCTRS-1189

- Add the option to duplicate a connector from **drawer** and **overview page** if KI no longer exists.

screenshot
![image](https://user-images.githubusercontent.com/8264372/182407956-fe015d05-ea92-4444-8f9c-c94af71f1006.png)
