### PR TITLE
feat: add a backend environment selector

### DIFF
--- a/src/app/components/AppLayout/AppLayout.tsx
+++ b/src/app/components/AppLayout/AppLayout.tsx
@@ -15,13 +15,17 @@ import {
 import logo from './Patternfly-Logo.svg';
 
 interface IAppLayout {
+  headerTools?: ReactNode;
   children: ReactNode;
 }
 
 /**
  * Mocks the chrome of an app running on consoles.redhat.com
  */
-export const AppLayout: FunctionComponent<IAppLayout> = ({ children }) => {
+export const AppLayout: FunctionComponent<IAppLayout> = ({
+  headerTools,
+  children,
+}) => {
   const [isNavOpen, setIsNavOpen] = useState(true);
   const [isMobileView, setIsMobileView] = useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = useState(false);
@@ -38,7 +42,9 @@ export const AppLayout: FunctionComponent<IAppLayout> = ({ children }) => {
     setIsMobileView(props.mobileView);
   };
 
-  const HeaderTools = <PageHeaderTools>{'email'}</PageHeaderTools>;
+  const HeaderTools = (
+    <PageHeaderTools>{headerTools ? headerTools : 'email'}</PageHeaderTools>
+  );
 
   const Header = (
     <PageHeader


### PR DESCRIPTION
This change adds a dropdown menu to select a backend instance, either
staging, development or local.  It stores the selection in local storage
so the last environment used will be selected.  This change also shows
the currently connected environment in the page header.

![image](https://user-images.githubusercontent.com/351660/185211811-6bfe9ef1-b665-4b67-bd59-88be90f36d46.png)

This beats forgetting to uncomment the right URL in the .env file when you need to work against a particular environment.