### PR TITLE
MGDCTRS-1420 fix: send the correct patch

### DIFF
--- a/cypress/e2e/connector-overview.cy.ts
+++ b/cypress/e2e/connector-overview.cy.ts
@@ -69,5 +69,31 @@ describe(
           },
         });
     });
+
+    it('should change the error handler from stop to log with the correct request', () => {
+      cy.visit(Cypress.env('overview'));
+      waitForData();
+      cy.findByText('Configuration').click();
+      cy.findAllByTestId('tab-error-handling').first().click();
+      cy.findByText('Edit Properties').click();
+      // workaround - select doesn't seem to use data-testid
+      cy.get('[data-ouia-component-id="select-error-handler"]').click();
+      cy.findByTestId('option-log').click();
+      cy.intercept(Cypress.env('overviewApiPath'), {
+        method: 'PATCH',
+        fixture: 'connectorOverview/cc1p3tjvcap6794aj210.json',
+      }).as('handlePatch');
+      cy.findByText('Save').click();
+      cy.wait('@handlePatch')
+        .its('request.body')
+        .should('deep.equal', {
+          connector: {
+            error_handler: {
+              log: {},
+              stop: null,
+            },
+          },
+        });
+    });
   }
 );

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -262,7 +262,10 @@ export const getConnectorTypeDetail = ({
       })
       .catch((error) => {
         if (!axios.isCancel(error)) {
-          console.log('Error:', error.response.data.reason);
+          console.log(
+            'error response fetching connector type:',
+            error.response.data.reason
+          );
         }
       });
     return () => {
@@ -632,7 +635,10 @@ export const getKafkaInstanceById = ({
       })
       .catch((error) => {
         if (!axios.isCancel(error)) {
-          console.log('Error msg:' + error.response);
+          console.log(
+            'error response fetching kafka: ',
+            error.response.data.reason
+          );
           onError(error.response);
         }
       });

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -1,5 +1,22 @@
 import _ from 'lodash';
 
+/**
+ * Creates a string suitable as an ID for HTML, OUIA or as a data-testid
+ * @param subject
+ * @param prefix
+ * @param suffix
+ * @returns
+ */
+export const toHtmlSafeId = (
+  subject: string,
+  prefix?: string,
+  suffix?: string
+) => {
+  return `${prefix ? prefix : ''}${subject
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .toLowerCase()}${suffix ? suffix : ''}`;
+};
+
 export const mapToObject = (inputMap: Map<string, unknown>): object => {
   const obj = {} as { [key: string]: unknown };
   inputMap.forEach((value, key) => {

--- a/test/shared.test.tsx
+++ b/test/shared.test.tsx
@@ -2,6 +2,7 @@ import {
   clearEmptyObjectValues,
   createDefaultFromSchema,
   resolveReference,
+  toHtmlSafeId,
 } from '../src/utils/shared';
 
 const testObj1 = {
@@ -162,6 +163,22 @@ describe('resolveReference', () => {
         required: ['format'],
         type: 'object',
       })
+    );
+  });
+});
+
+describe('toHtmlSafeId', () => {
+  it('should work without a prefix or suffix, converting characters as needed', () => {
+    expect(toHtmlSafeId('Cheese Sticks!')).toEqual('cheese-sticks-');
+  });
+  it('should work with a prefix', () => {
+    expect(toHtmlSafeId('Cheese Sticks!', 'delicious-')).toEqual(
+      'delicious-cheese-sticks-'
+    );
+  });
+  it('should work with a suffix', () => {
+    expect(toHtmlSafeId('Cheese Sticks!', 'delicious-', 'things')).toEqual(
+      'delicious-cheese-sticks-things'
     );
   });
 });


### PR DESCRIPTION
This changes adjusts the overview to send the correct patch request when the user changes the error handling strategy.  This change also adds tests and tries to add a little bit more type info given that error handling doesn't yet seem to be exposed by the API.

Oh, also I changed a couple console.log statements in the API just to make them more consistent.