### PR TITLE
MGDCTRS-1477 chore: select connector type story

### DIFF
--- a/src/app/components/ConnectorTypeCard/ConnectorTypeCard.stories.tsx
+++ b/src/app/components/ConnectorTypeCard/ConnectorTypeCard.stories.tsx
@@ -12,7 +12,7 @@ import connectorTypeData from '../../../../cypress/fixtures/connectorTypes2.json
 import { ConnectorTypeCard } from './ConnectorTypeCard';
 
 export default {
-  title: 'Wizard Step 1/Connector cards',
+  title: 'Wizard Step 1/Components/Connector cards',
   component: ConnectorTypeCard,
   decorators: [(Story) => <Story />],
   args: {},
@@ -75,7 +75,7 @@ const TemplateList: ComponentStory<typeof ConnectorTypeCard> = (args) => (
           id={(c as ObjectReference).id!}
           labels={(c as ConnectorTypeAllOf).labels!}
           name={(c as ConnectorTypeAllOf).name!}
-          description={(c as ConnectorTypeAllOf)?.description}
+          description={(c as ConnectorTypeAllOf)?.description!}
           version={(c as ConnectorTypeAllOf).version!}
           selectedId={''}
           onSelect={() => {}}

--- a/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
+++ b/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
@@ -230,7 +230,7 @@ export const useCreateConnectorWizardService = () => {
   const service = useContext(CreateConnectorWizardMachineService);
   if (!service) {
     throw new Error(
-      `useCreationWizardMachineService() must be used in a child of <CreationWizardMachineProvider>`
+      `useCreateConnectorWizardService() must be used as a child of <CreateConnectorWizardProvider>`
     );
   }
   return service;

--- a/src/app/pages/CreateConnectorPage/StepConnectorTypes.stories.tsx
+++ b/src/app/pages/CreateConnectorPage/StepConnectorTypes.stories.tsx
@@ -1,0 +1,93 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { rest } from 'msw';
+import React from 'react';
+
+import { CreateConnectorWizardProvider } from '../../components/CreateConnectorWizard/CreateConnectorWizardContext';
+import { SelectConnectorType } from './StepConnectorTypes';
+
+const API_HOST = 'https://dummy.server';
+const API = `${API_HOST}/api/connector_mgmt/v1/kafka_connector_types`;
+
+export default {
+  title: 'Wizard Step 1/Connector Type Step',
+  component: SelectConnectorType,
+  decorators: [
+    (Story) => (
+      <CreateConnectorWizardProvider
+        accessToken={() => Promise.resolve('')}
+        connectorsApiBasePath={API_HOST}
+        kafkaManagementApiBasePath={''}
+        fetchConfigurator={() => Promise.resolve(undefined)}
+        onSave={(name: string) => console.debug('onSave, name: ', name)}
+      >
+        <Story />
+      </CreateConnectorWizardProvider>
+    ),
+  ],
+  args: {},
+  parameters: {
+    xstate: true,
+  },
+} as ComponentMeta<typeof SelectConnectorType>;
+
+const Template: ComponentStory<typeof SelectConnectorType> = () => (
+  <SelectConnectorType />
+);
+
+export const InitialLoading = Template.bind({});
+InitialLoading.parameters = {
+  msw: [
+    rest.get(API, (_req, res, ctx) => {
+      return res(ctx.delay(80000), ctx.status(403));
+    }),
+  ],
+};
+
+export const WithConnectorTypes = Template.bind({});
+WithConnectorTypes.parameters = {
+  msw: [
+    rest.get(`${API}*`, (req, res, ctx) => {
+      const searchParams = req.url.searchParams;
+      const page = +(searchParams.get('page') || 1);
+      const size = +(searchParams.get('size') || 20);
+      const search = searchParams.get('search') || '';
+      const response = generateStoryConnectorTypes(page, size, search, 60);
+      return res(ctx.delay(300), ctx.json(response));
+    }),
+  ],
+};
+
+export const WithError = Template.bind({});
+WithError.parameters = {
+  msw: [
+    rest.get(API, (_req, res, ctx) => {
+      return res(ctx.status(403));
+    }),
+  ],
+};
+
+// generate a deterministic set of connector types
+const generateStoryConnectorTypes = (page, size, search, total) => {
+  const fullSet = Array.from(
+    {
+      length: total,
+    },
+    (_, index) => ({
+      name: `Some Connector ${index}`,
+      id: `connector_${index}`,
+      version: `some_version_${index}`,
+      description: `This is a fancy connector description for Some Connector ${index}`,
+      labels: index % 2 ? ['source'] : ['sink'],
+    })
+  );
+  const start = (page - 1) * size;
+  const end = start + size;
+  return {
+    page,
+    size,
+    items: fullSet
+      .slice(start, end)
+      .filter(({ name }) => name.includes(search)),
+    total,
+  };
+};

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -13,18 +13,3 @@ export enum CONNECTOR_DETAILS_TABS {
   Overview = 'overview',
   Configuration = 'configuration',
 }
-
-export const defaultPerPageOptions = [
-  {
-    title: '1',
-    value: 1,
-  },
-  {
-    title: '5',
-    value: 5,
-  },
-  {
-    title: '10',
-    value: 10,
-  },
-];


### PR DESCRIPTION
This change adds a story that loads the Select Connector Type step from the wizard and mocks the API.  There's also a couple of small cleanup items, an update to the error string when the trying to use the wizard without it's provider and removal of an unused constant.