### PR TITLE
MGDCTRS-1476 fix: avoid false positive

### DIFF
--- a/src/app/machines/PaginatedResponse.machine.ts
+++ b/src/app/machines/PaginatedResponse.machine.ts
@@ -428,7 +428,9 @@ export const usePagination = <RawDataType, OrderBy, Search, DataType>(
           loading: state.hasTag('loading'),
           queryEmpty: state.hasTag('queryEmpty'),
           queryResults: state.hasTag('queryResults'),
-          noResults: state.context.response?.items?.length === 0,
+          noResults:
+            !state.hasTag('loading') &&
+            state.context.response?.items?.length === 0,
           results: state.hasTag('results'),
           error: state.hasTag('error'),
           firstRequest: state.context.response === undefined,


### PR DESCRIPTION
This change takes the loading state into account when calculating if there are query results available and fixes a small issue where the wrong error component is shown as the user interacts with the connector type filter.