### PR TITLE
MGDCTRS-1068 fix: add an analytics hook

### DIFF
--- a/src/AppDemo.tsx
+++ b/src/AppDemo.tsx
@@ -1,6 +1,7 @@
 import { AlertsProvider } from '@app/components/Alerts/Alerts';
 import { AppLayout } from '@app/components/AppLayout/AppLayout';
 import { Loading } from '@app/components/Loading/Loading';
+import { AnalyticsProvider } from '@hooks/useAnalytics';
 import i18n from '@i18n/i18n';
 import Keycloak from 'keycloak-js';
 import React, {
@@ -157,13 +158,15 @@ const ConnectedAppDemo: FunctionComponent<ConnectedAppDemoProps> = ({
   >
     <I18nextProvider i18n={i18n}>
       <AlertsProvider>
-        <React.Suspense fallback={<Loading />}>
-          <Router>
-            <AppLayout headerTools={headerTools}>
-              {initialized ? <ConnectedRoutes /> : <Spinner />}
-            </AppLayout>
-          </Router>
-        </React.Suspense>
+        <AnalyticsProvider>
+          <React.Suspense fallback={<Loading />}>
+            <Router>
+              <AppLayout headerTools={headerTools}>
+                {initialized ? <ConnectedRoutes /> : <Spinner />}
+              </AppLayout>
+            </Router>
+          </React.Suspense>
+        </AnalyticsProvider>
       </AlertsProvider>
     </I18nextProvider>
   </ConfigContext.Provider>
@@ -178,15 +181,6 @@ const ConnectedRoutes: FunctionComponent<{}> = () => {
       connectorsApiBasePath={config?.cos.apiBasePath || ''}
       // TODO: remove after demo
       kafkaManagementApiBasePath={'https://api.openshift.com'}
-      onActivity={(event, properties) =>
-        console.debug
-          ? console.debug(
-              'user activity, name: ',
-              event,
-              properties ? ` properties:  ${JSON.stringify(properties)}` : ''
-            )
-          : false
-      }
     />
   );
 };

--- a/src/AppE2E.tsx
+++ b/src/AppE2E.tsx
@@ -1,6 +1,7 @@
 import { AlertsProvider } from '@app/components/Alerts/Alerts';
 import { AppLayout } from '@app/components/AppLayout/AppLayout';
 import { Loading } from '@app/components/Loading/Loading';
+import { AnalyticsProvider } from '@hooks/useAnalytics';
 import i18n from '@i18n/i18n';
 import React, { FunctionComponent, useCallback } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -67,13 +68,15 @@ export const AppE2E: FunctionComponent = () => {
         <ConfigContext.Provider value={config}>
           <I18nextProvider i18n={i18n}>
             <AlertsProvider>
-              <React.Suspense fallback={<Loading />}>
-                <Router>
-                  <AppLayout>
-                    <ConnectedRoutes />
-                  </AppLayout>
-                </Router>
-              </React.Suspense>
+              <AnalyticsProvider>
+                <React.Suspense fallback={<Loading />}>
+                  <Router>
+                    <AppLayout>
+                      <ConnectedRoutes />
+                    </AppLayout>
+                  </Router>
+                </React.Suspense>
+              </AnalyticsProvider>
             </AlertsProvider>
           </I18nextProvider>
         </ConfigContext.Provider>
@@ -92,15 +95,6 @@ const ConnectedRoutes = () => {
       connectorsApiBasePath={config?.cos.apiBasePath || ''}
       // TODO: remove after demo
       kafkaManagementApiBasePath={'localhost'}
-      onActivity={(event, properties) =>
-        console.debug
-          ? console.debug(
-              'user activity, name: ',
-              event,
-              properties ? ` properties:  ${JSON.stringify(properties)}` : ''
-            )
-          : false
-      }
     />
   );
 };

--- a/src/AppFederated.tsx
+++ b/src/AppFederated.tsx
@@ -1,4 +1,5 @@
 import { Loading } from '@app/components/Loading/Loading';
+import { AnalyticsProvider } from '@hooks/useAnalytics';
 import i18n from '@i18n/i18n';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import React, { FunctionComponent } from 'react';
@@ -27,19 +28,22 @@ export const AppFederated: FunctionComponent = () => {
   };
   return (
     <I18nextProvider i18n={i18n}>
-      <React.Suspense fallback={<Loading />}>
-        <Router basename={basename?.getBasename()}>
-          <CosRoutes
-            getToken={async () => (await auth?.kas.getToken()) || ''}
-            connectorsApiBasePath={config?.cos.apiBasePath || ''}
-            // TODO: remove after demo
-            kafkaManagementApiBasePath={'https://api.openshift.com'}
-            onActivity={(event, properties) =>
-              analytics ? analytics.track(event, properties) : false
-            }
-          />
-        </Router>
-      </React.Suspense>
+      <AnalyticsProvider
+        onActivity={(event, properties) =>
+          analytics ? analytics.track(event, properties) : false
+        }
+      >
+        <React.Suspense fallback={<Loading />}>
+          <Router basename={basename?.getBasename()}>
+            <CosRoutes
+              getToken={async () => (await auth?.kas.getToken()) || ''}
+              connectorsApiBasePath={config?.cos.apiBasePath || ''}
+              // TODO: remove after demo
+              kafkaManagementApiBasePath={'https://api.openshift.com'}
+            />
+          </Router>
+        </React.Suspense>
+      </AnalyticsProvider>
     </I18nextProvider>
   );
 };

--- a/src/CosRoutes.tsx
+++ b/src/CosRoutes.tsx
@@ -8,20 +8,18 @@ import { Route, Switch, useHistory } from 'react-router-dom';
 import { useTranslation } from '@rhoas/app-services-ui-components';
 import { AlertVariant, useAlert } from '@rhoas/app-services-ui-shared';
 
-import { CosContextProvider } from './context/CosContext';
+import { CosContextProvider } from './hooks/useCos';
 
 type CosRoutesProps = {
   getToken: () => Promise<string>;
   connectorsApiBasePath: string;
   kafkaManagementApiBasePath: string;
-  onActivity: (event: string, properties?: unknown) => void;
 };
 
 export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
   getToken,
   connectorsApiBasePath,
   kafkaManagementApiBasePath,
-  onActivity,
 }) => {
   const { t } = useTranslation();
   const alert = useAlert();
@@ -65,7 +63,6 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
       getToken={getToken}
       connectorsApiBasePath={connectorsApiBasePath}
       kafkaManagementApiBasePath={kafkaManagementApiBasePath}
-      onActivity={onActivity}
     >
       <Switch>
         <Route path={'/'} exact>

--- a/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
+++ b/src/app/components/ConnectorDrawer/ConnectorDrawer.tsx
@@ -4,7 +4,7 @@ import {
   ConnectorMachineActorRef,
   useConnector,
 } from '@app/machines/Connector.machine';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import React, {
   FunctionComponent,
   ReactNode,

--- a/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
+++ b/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
@@ -27,7 +27,7 @@ import { ConnectorTypesMachineActorRef } from '@app/machines/StepSelectConnector
 import { KafkaMachineActorRef } from '@app/machines/StepSelectKafka.machine';
 import { NamespaceMachineActorRef } from '@app/machines/StepSelectNamespace.machine';
 import { PAGINATED_MACHINE_ID } from '@constants/constants';
-import { useCos } from '@context/CosContext';
+import { useAnalytics } from '@hooks/useAnalytics';
 import React, {
   createContext,
   FunctionComponent,
@@ -80,7 +80,7 @@ export const CreateConnectorWizardProvider: FunctionComponent<CreateConnectorWiz
     connectorId,
     duplicateMode,
   }) => {
-    const { onActivity } = useCos();
+    const { onActivity } = useAnalytics();
     const makeConfiguratorLoaderMachine = useCallback(
       () =>
         configuratorLoaderMachine.withConfig({
@@ -279,7 +279,7 @@ export const useConnectorTypesMachineIsReady = () => {
 
 export const useConnectorTypesMachine = () => {
   const { connectorTypeRef } = useCreateConnectorWizard();
-  const { onActivity } = useCos();
+  const { onActivity } = useAnalytics();
 
   const api = usePagination<
     ConnectorType,
@@ -352,7 +352,7 @@ export const useKafkasMachineIsReady = () => {
 
 export const useKafkasMachine = () => {
   const { kafkaRef } = useCreateConnectorWizard();
-  const { onActivity } = useCos();
+  const { onActivity } = useAnalytics();
   const api = usePagination<
     KafkaRequest,
     PlaceholderOrderBy,
@@ -425,7 +425,7 @@ export const useNamespaceMachineIsReady = () => {
 
 export const useNamespaceMachine = () => {
   const { namespaceRef } = useCreateConnectorWizard();
-  const { onActivity } = useCos();
+  const { onActivity } = useAnalytics();
   const api = usePagination<
     ConnectorNamespace,
     PlaceholderOrderBy,

--- a/src/app/components/CreateServiceAccount/CreateServiceAccount.stories.tsx
+++ b/src/app/components/CreateServiceAccount/CreateServiceAccount.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 
-import { CosContextProvider } from '../../../context/CosContext';
+import { CosContextProvider } from '../../../hooks/useCos';
 import { AlertsProvider } from '../Alerts/Alerts';
 import { CreateServiceAccount } from './CreateServiceAccount';
 

--- a/src/app/components/CreateServiceAccount/CreateServiceAccount.tsx
+++ b/src/app/components/CreateServiceAccount/CreateServiceAccount.tsx
@@ -1,5 +1,5 @@
 import { createServiceAccount, UserProvidedServiceAccount } from '@apis/api';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import React, { FormEvent, useCallback, useState } from 'react';
 import { FC } from 'react';
 

--- a/src/app/components/RegisterEvalNamespace/RegisterEvalNamespace.tsx
+++ b/src/app/components/RegisterEvalNamespace/RegisterEvalNamespace.tsx
@@ -1,5 +1,5 @@
 import { registerEvalNamespace } from '@apis/api';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import {

--- a/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConfigurationTab.tsx
@@ -5,7 +5,7 @@ import {
   ConfigurationMode,
   ConnectorConfiguratorComponent,
 } from '@app/machines/StepConfiguratorLoader.machine';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import { clearEmptyObjectValues, toHtmlSafeId } from '@utils/shared';
 import _ from 'lodash';

--- a/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
+++ b/src/app/pages/ConnectorDetailsPage/ConnectorDetailsPage.tsx
@@ -1,7 +1,7 @@
 import { getConnector, getConnectorTypeDetail } from '@apis/api';
 import { Loading } from '@app/components/Loading/Loading';
 import { CONNECTOR_DETAILS_TABS } from '@constants/constants';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import _ from 'lodash';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';

--- a/src/app/pages/ConnectorDetailsPage/OverviewTab.tsx
+++ b/src/app/pages/ConnectorDetailsPage/OverviewTab.tsx
@@ -1,6 +1,6 @@
 import { getKafkaInstanceById, getNamespace } from '@apis/api';
 import { ConnectorInfoTextList } from '@app/components/ConnectorInfoTextList/ConnectorInfoTextList';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import {

--- a/src/app/pages/ConnectorsPage/ConnectorsPage.tsx
+++ b/src/app/pages/ConnectorsPage/ConnectorsPage.tsx
@@ -13,7 +13,7 @@ import {
   ConnectorMachineActorRef,
   useConnector,
 } from '@app/machines/Connector.machine';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import React, {
   FunctionComponent,
   useCallback,

--- a/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
+++ b/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
@@ -1,6 +1,6 @@
 import { CreateConnectorWizard } from '@app/components/CreateConnectorWizard/CreateConnectorWizard';
 import { CreateConnectorWizardProvider } from '@app/components/CreateConnectorWizard/CreateConnectorWizardContext';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import React, { FunctionComponent, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/src/app/pages/CreateConnectorPage/DuplicateConnectorPage.tsx
+++ b/src/app/pages/CreateConnectorPage/DuplicateConnectorPage.tsx
@@ -2,7 +2,7 @@ import { getConnector, getConnectorTypeDetail } from '@apis/api';
 import { CreateConnectorWizard } from '@app/components/CreateConnectorWizard/CreateConnectorWizard';
 import { CreateConnectorWizardProvider } from '@app/components/CreateConnectorWizard/CreateConnectorWizardContext';
 import { Loading } from '@app/components/Loading/Loading';
-import { useCos } from '@context/CosContext';
+import { useCos } from '@hooks/useCos';
 import { fetchConfigurator } from '@utils/loadFederatedConfigurator';
 import _ from 'lodash';
 import React, {

--- a/src/hooks/useAnalytics.tsx
+++ b/src/hooks/useAnalytics.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, FunctionComponent, useContext } from 'react';
+
+type AnalyticsContextType = {
+  onActivity?: (eventName: string, properties?: unknown) => void;
+};
+const AnalyticsContext = createContext<AnalyticsContextType>({});
+
+export const AnalyticsProvider: FunctionComponent<AnalyticsContextType> = ({
+  children,
+  onActivity,
+}) => (
+  <AnalyticsContext.Provider value={{ onActivity }}>
+    {children}
+  </AnalyticsContext.Provider>
+);
+
+export const useAnalytics: () => {
+  onActivity: (eventName: string, properties?: unknown) => void;
+} = () => {
+  const context = useContext(AnalyticsContext);
+  if (!context || !context.onActivity) {
+    return {
+      onActivity: (eventName: string, properties?: unknown) => {
+        console.debug
+          ? console.debug(
+              'user activity, name: ',
+              eventName,
+              properties ? ` properties:  ${JSON.stringify(properties)}` : ''
+            )
+          : false;
+      },
+    };
+  }
+  return {
+    onActivity: context!.onActivity!,
+  };
+};

--- a/src/hooks/useCos.tsx
+++ b/src/hooks/useCos.tsx
@@ -14,7 +14,6 @@ type AppContextType = {
    */
   connectorsApiBasePath: string;
   kafkaManagementApiBasePath: string;
-  onActivity: (eventName: string, payload?: unknown) => void;
 };
 const CosContext = createContext<AppContextType | null>(null);
 
@@ -22,7 +21,6 @@ export const CosContextProvider: FunctionComponent<AppContextType> = ({
   getToken,
   connectorsApiBasePath,
   kafkaManagementApiBasePath,
-  onActivity,
   children,
 }) => (
   <CosContext.Provider
@@ -30,7 +28,6 @@ export const CosContextProvider: FunctionComponent<AppContextType> = ({
       getToken,
       connectorsApiBasePath,
       kafkaManagementApiBasePath,
-      onActivity,
     }}
   >
     {children}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "@apis/*":["src/apis/*"],
       "@constants/*":["src/constants/*"],
       "@utils/*":["src/utils/*"],
-      "@context/*":["src/context/*"]
+      "@hooks/*":["src/hooks/*"]
     },
   }
 }


### PR DESCRIPTION
This change updates how analytics are made available to the app via using a custom hook that's configurable via a context.  This change also updates the directory structure and filenames for clarity, i.e. "context" to "hooks" for hooks that cover app-wide concerns such as analytics or basic app configuration like the existing useCos hook.

I totally should have done this the first time around :-)