### PR TITLE
MGDCTRS-1477 feat: add a card layout variant

### DIFF
--- a/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGallery.stories.tsx
+++ b/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGallery.stories.tsx
@@ -50,14 +50,12 @@ const categories = [
   'Azure',
 ];
 
-const CONNECTOR_COUNT = 2350;
-const FEATURED_COUNT = 25;
+const CONNECTOR_COUNT = 235;
+const FEATURED_COUNT = 5;
 const CONNECTOR_TYPES_API = `${API_HOST}/api/connector_mgmt/v1/kafka_connector_types`;
 const CONNECTOR_LABELS_API = `${API_HOST}/api/connector_mgmt/v1/kafka_connector_types/labels`;
 
-export const WithConnectorTypes = Template.bind({});
-WithConnectorTypes.args = {};
-WithConnectorTypes.parameters = {
+const SHARED_PARAMETERS = {
   msw: [
     rest.get(`${CONNECTOR_LABELS_API}*`, (req, res, ctx) => {
       const { search, orderBy } = getPaginationCriteria(req.url.searchParams);
@@ -83,6 +81,13 @@ WithConnectorTypes.parameters = {
     }),
   ],
 };
+export const WithConnectorTypesList = Template.bind({});
+WithConnectorTypesList.args = {};
+WithConnectorTypesList.parameters = { ...SHARED_PARAMETERS };
+
+export const WithConnectorTypesCards = Template.bind({});
+WithConnectorTypesCards.args = { useMasonry: true };
+WithConnectorTypesCards.parameters = { ...SHARED_PARAMETERS };
 
 function generateConnectorTypesResponse(page, size, search, orderBy, total) {
   const start = (page - 1) * size;

--- a/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryCache.tsx
+++ b/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryCache.tsx
@@ -14,6 +14,7 @@ export type ConnectorTypesGalleryCacheContextType = {
     stopIndex: number;
   }) => Promise<void>;
   getRow: (props: { index: number }) => FeaturedConnectorType | boolean;
+  useMasonry: boolean;
 };
 
 const ConnectorTypesGalleryCacheContext =
@@ -21,6 +22,7 @@ const ConnectorTypesGalleryCacheContext =
     isRowLoaded: (_) => false,
     loadMoreRows: (_) => Promise.resolve(),
     getRow: (_) => false,
+    useMasonry: false,
   });
 
 export type ConnectorTypesGalleryCacheContextProviderProps = {
@@ -32,6 +34,7 @@ export type ConnectorTypesGalleryCacheContextProviderProps = {
   page: number;
   size: number;
   total: number;
+  useMasonry?: boolean;
 };
 
 export const ConnectorTypesGalleryCacheProvider: FC<ConnectorTypesGalleryCacheContextProviderProps> =
@@ -44,6 +47,7 @@ export const ConnectorTypesGalleryCacheProvider: FC<ConnectorTypesGalleryCacheCo
     page,
     size,
     total,
+    useMasonry,
     children,
   }) => {
     let highestLoadedPage = page;
@@ -100,6 +104,7 @@ export const ConnectorTypesGalleryCacheProvider: FC<ConnectorTypesGalleryCacheCo
           isRowLoaded,
           loadMoreRows,
           getRow,
+          useMasonry: !!useMasonry,
         }}
       >
         {children}

--- a/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryCard.tsx
+++ b/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryCard.tsx
@@ -26,6 +26,8 @@ import {
 
 import { useTranslation } from '@rhoas/app-services-ui-components';
 
+import { useConnectorTypesGalleryCache } from './ConnectorTypesGalleryCache';
+
 export type ConnectorTypesGalleryCardProps = {
   id: string;
   labels: string[];
@@ -49,6 +51,7 @@ export const ConnectorTypesGalleryCard: FunctionComponent<ConnectorTypesGalleryC
     onSelect,
   }) => {
     const { t } = useTranslation();
+    const { useMasonry } = useConnectorTypesGalleryCache();
     return (
       <Card
         key={id}
@@ -56,6 +59,7 @@ export const ConnectorTypesGalleryCard: FunctionComponent<ConnectorTypesGalleryC
         isSelectable
         isSelected={selectedId === id}
         onClick={() => onSelect(id)}
+        style={useMasonry ? { height: 250, width: 300 } : {}}
       >
         <CardHeader>
           {labels.includes('source') ? (

--- a/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryWrapper.tsx
+++ b/src/ProofOfConcepts/ConnectorTypesGallery/ConnectorTypesGalleryWrapper.tsx
@@ -17,9 +17,11 @@ import {
   FeaturedConnectorType,
 } from './typeExtensions';
 
-export type ConnectorTypesGalleryWrapperProps = {};
+export type ConnectorTypesGalleryWrapperProps = {
+  useMasonry?: boolean;
+};
 export const ConnectorTypesGalleryWrapper: FC<ConnectorTypesGalleryWrapperProps> =
-  ({}) => {
+  ({ useMasonry }) => {
     const { t } = useTranslation();
     const { connectorsApiBasePath, getToken } = useCos();
     const [connectorTypes, setConnectorTypes] = useState<
@@ -190,6 +192,7 @@ export const ConnectorTypesGalleryWrapper: FC<ConnectorTypesGalleryWrapperProps>
           page={page}
           size={size}
           total={total}
+          useMasonry={useMasonry}
         >
           <ConnectorTypesGallery
             total={total}


### PR DESCRIPTION
This change adds a 2nd story that shows a card layout using Masonry from react-virtualized.

In a list layout:
![Screenshot from 2022-11-03 12-18-25](https://user-images.githubusercontent.com/351660/199776096-a9b25e1a-b726-4176-86b4-dfa3df3948d9.png)

And in the card layout:
![Screenshot from 2022-11-03 12-18-17](https://user-images.githubusercontent.com/351660/199776148-c9475dfe-06f0-496f-aeec-cd0d13062f79.png)

this also reduces the number of items to a more sensible number :smile: 