### PR TITLE
MGDCTRS-1438 feat: dynamic form improvements

### DIFF
--- a/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
+++ b/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
@@ -1,227 +1,197 @@
 {
-  "id": "aws_kinesis_source_0.1",
-  "kind": "ConnectorType",
-  "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_kinesis_source_0.1",
-  "name": "Amazon Kinesis source",
-  "version": "0.1",
-  "channels": [
-    "stable"
-  ],
-  "description": "Receive data from Amazon Kinesis.",
-  "icon_href": "TODO",
-  "labels": [
-    "source"
-  ],
-  "capabilities": [
-    "data_shape",
-    "error_handler",
-    "processors"
-  ],
-  "schema": {
-    "$defs": {
-      "data_shape": {
-        "consumes": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        },
-        "produces": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        }
-      },
-      "error_handler": {
-        "dead_letter_queue": {
-          "additionalProperties": false,
-          "properties": {
-            "topic": {
-              "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
-              "title": "Dead Letter Topic Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "topic"
-          ],
-          "type": "object"
-        },
-        "log": {
-          "additionalProperties": false,
-          "type": "object"
-        },
-        "stop": {
-          "additionalProperties": false,
-          "type": "object"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "properties": {
-      "aws_access_key": {
-        "oneOf": [
-          {
-            "description": "The access key obtained from AWS.",
-            "format": "password",
-            "title": "Access Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_access_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Access Key",
-        "x-group": "credentials"
-      },
-      "aws_delay": {
-        "default": 500,
-        "description": "The number of milliseconds before the next poll of the selected stream.",
-        "title": "Delay",
-        "type": "integer"
-      },
-      "aws_override_endpoint": {
-        "default": false,
-        "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
-        "title": "Endpoint Overwrite",
-        "type": "boolean"
-      },
-      "aws_region": {
-        "description": "The AWS region to access.",
-        "example": "eu-west-1",
-        "title": "AWS Region",
-        "type": "string"
-      },
-      "aws_secret_key": {
-        "oneOf": [
-          {
-            "description": "The secret key obtained from AWS.",
-            "format": "password",
-            "title": "Secret Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_secret_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Secret Key",
-        "x-group": "credentials"
-      },
-      "aws_stream": {
-        "description": "The Kinesis stream that you want to access. The Kinesis stream that you specify must already exist.",
-        "title": "Stream Name",
-        "type": "string"
-      },
-      "aws_uri_endpoint_override": {
-        "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
-        "title": "Overwrite Endpoint URI",
-        "type": "string"
-      },
-      "data_shape": {
-        "additionalProperties": false,
-        "properties": {
+  "connector_type": {
+    "id": "aws_kinesis_source_0.1",
+    "kind": "ConnectorType",
+    "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_kinesis_source_0.1",
+    "name": "Amazon Kinesis source",
+    "version": "0.1",
+    "channels": ["stable"],
+    "description": "Receive data from Amazon Kinesis.",
+    "icon_href": "TODO",
+    "labels": ["source"],
+    "capabilities": ["data_shape", "error_handler", "processors"],
+    "schema": {
+      "$defs": {
+        "data_shape": {
           "consumes": {
-            "$ref": "#/$defs/data_shape/consumes"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           },
           "produces": {
-            "$ref": "#/$defs/data_shape/produces"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           }
         },
-        "type": "object"
-      },
-      "error_handler": {
-        "default": {
+        "error_handler": {
+          "dead_letter_queue": {
+            "additionalProperties": false,
+            "properties": {
+              "topic": {
+                "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
+                "title": "Dead Letter Topic Name",
+                "type": "string"
+              }
+            },
+            "required": ["topic"],
+            "type": "object"
+          },
+          "log": {
+            "additionalProperties": false,
+            "type": "object"
+          },
           "stop": {
-            
+            "additionalProperties": false,
+            "type": "object"
           }
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "aws_access_key": {
+          "oneOf": [
+            {
+              "description": "The access key obtained from AWS.",
+              "format": "password",
+              "title": "Access Key",
+              "type": "string"
+            },
+            {
+              "description": "An opaque reference to the aws_access_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Access Key",
+          "x-group": "credentials"
         },
-        "oneOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "log": {
-                "$ref": "#/$defs/error_handler/log"
-              }
+        "aws_delay": {
+          "default": 500,
+          "description": "The number of milliseconds before the next poll of the selected stream.",
+          "title": "Delay",
+          "type": "integer"
+        },
+        "aws_override_endpoint": {
+          "default": false,
+          "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
+          "title": "Endpoint Overwrite",
+          "type": "boolean"
+        },
+        "aws_region": {
+          "description": "The AWS region to access.",
+          "example": "eu-west-1",
+          "title": "AWS Region",
+          "type": "string"
+        },
+        "aws_secret_key": {
+          "oneOf": [
+            {
+              "description": "The secret key obtained from AWS.",
+              "format": "password",
+              "title": "Secret Key",
+              "type": "string"
             },
-            "required": [
-              "log"
-            ],
-            "type": "object"
+            {
+              "description": "An opaque reference to the aws_secret_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Secret Key",
+          "x-group": "credentials"
+        },
+        "aws_stream": {
+          "description": "The Kinesis stream that you want to access. The Kinesis stream that you specify must already exist.",
+          "title": "Stream Name",
+          "type": "string"
+        },
+        "aws_uri_endpoint_override": {
+          "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
+          "title": "Overwrite Endpoint URI",
+          "type": "string"
+        },
+        "data_shape": {
+          "additionalProperties": false,
+          "properties": {
+            "consumes": {
+              "$ref": "#/$defs/data_shape/consumes"
+            },
+            "produces": {
+              "$ref": "#/$defs/data_shape/produces"
+            }
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "stop": {
-                "$ref": "#/$defs/error_handler/stop"
-              }
-            },
-            "required": [
-              "stop"
-            ],
-            "type": "object"
+          "type": "object"
+        },
+        "error_handler": {
+          "default": {
+            "stop": {}
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "dead_letter_queue": {
-                "$ref": "#/$defs/error_handler/dead_letter_queue"
-              }
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "log": {
+                  "$ref": "#/$defs/error_handler/log"
+                }
+              },
+              "required": ["log"],
+              "type": "object"
             },
-            "required": [
-              "dead_letter_queue"
-            ],
-            "type": "object"
-          }
-        ],
-        "type": "object"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "stop": {
+                  "$ref": "#/$defs/error_handler/stop"
+                }
+              },
+              "required": ["stop"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "dead_letter_queue": {
+                  "$ref": "#/$defs/error_handler/dead_letter_queue"
+                }
+              },
+              "required": ["dead_letter_queue"],
+              "type": "object"
+            }
+          ],
+          "type": "object"
+        },
+        "kafka_topic": {
+          "description": "The name of the Kafka Topic to use.",
+          "title": "Topic Name",
+          "type": "string"
+        },
+        "processors": {}
       },
-      "kafka_topic": {
-        "description": "The name of the Kafka Topic to use.",
-        "title": "Topic Name",
-        "type": "string"
-      },
-      "processors": {
-        
-      }
-    },
-    "required": [
-      "aws_stream",
-      "aws_region",
-      "kafka_topic",
-      "aws_access_key",
-      "aws_secret_key"
-    ],
-    "type": "object"
+      "required": [
+        "aws_stream",
+        "aws_region",
+        "kafka_topic",
+        "aws_access_key",
+        "aws_secret_key"
+      ],
+      "type": "object"
+    }
   }
 }

--- a/cypress/fixtures/connectors/aws_s3_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_s3_sink_0.1.json
@@ -1,246 +1,220 @@
 {
-  "id": "aws_s3_sink_0.1",
-  "kind": "ConnectorType",
-  "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_s3_sink_0.1",
-  "name": "Amazon S3 sink",
-  "version": "0.1",
-  "channels": [
-    "stable"
-  ],
-  "description": "Send data to an Amazon S3 bucket.",
-  "icon_href": "TODO",
-  "labels": [
-    "sink"
-  ],
-  "capabilities": [
-    "data_shape",
-    "error_handler",
-    "processors"
-  ],
-  "schema": {
-    "$defs": {
-      "data_shape": {
-        "consumes": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        }
-      },
-      "error_handler": {
-        "dead_letter_queue": {
-          "additionalProperties": false,
-          "properties": {
-            "topic": {
-              "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
-              "title": "Dead Letter Topic Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "topic"
-          ],
-          "type": "object"
-        },
-        "log": {
-          "additionalProperties": false,
-          "type": "object"
-        },
-        "stop": {
-          "additionalProperties": false,
-          "type": "object"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "properties": {
-      "aws_access_key": {
-        "oneOf": [
-          {
-            "description": "The access key obtained from AWS.",
-            "format": "password",
-            "title": "Access Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_access_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Access Key",
-        "x-group": "credentials"
-      },
-      "aws_auto_create_bucket": {
-        "default": false,
-        "description": "Specifies to automatically create the S3 bucket.",
-        "title": "Autocreate Bucket",
-        "type": "boolean"
-      },
-      "aws_bucket_name_or_arn": {
-        "description": "The S3 Bucket name or Amazon Resource Name (ARN).",
-        "title": "Bucket Name",
-        "type": "string"
-      },
-      "aws_key_name": {
-        "description": "The key name for saving an element in the bucket.",
-        "title": "Key Name",
-        "type": "string"
-      },
-      "aws_override_endpoint": {
-        "default": false,
-        "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
-        "title": "Endpoint Overwrite",
-        "type": "boolean"
-      },
-      "aws_region": {
-        "description": "The AWS region to access.",
-        "enum": [
-          "af-south-1",
-          "ap-east-1",
-          "ap-northeast-1",
-          "ap-northeast-2",
-          "ap-northeast-3",
-          "ap-south-1",
-          "ap-southeast-1",
-          "ap-southeast-2",
-          "ap-southeast-3",
-          "ca-central-1",
-          "eu-central-1",
-          "eu-north-1",
-          "eu-south-1",
-          "eu-west-1",
-          "eu-west-2",
-          "eu-west-3",
-          "fips-us-east-1",
-          "fips-us-east-2",
-          "fips-us-west-1",
-          "fips-us-west-2",
-          "me-south-1",
-          "sa-east-1",
-          "us-east-1",
-          "us-east-2",
-          "us-west-1",
-          "us-west-2",
-          "cn-north-1",
-          "cn-northwest-1",
-          "us-gov-east-1",
-          "us-gov-west-1",
-          "us-iso-east-1",
-          "us-iso-west-1",
-          "us-isob-east-1"
-        ],
-        "title": "AWS Region",
-        "type": "string"
-      },
-      "aws_secret_key": {
-        "oneOf": [
-          {
-            "description": "The secret key obtained from AWS.",
-            "format": "password",
-            "title": "Secret Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_secret_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Secret Key",
-        "x-group": "credentials"
-      },
-      "aws_uri_endpoint_override": {
-        "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
-        "title": "Overwrite Endpoint URI",
-        "type": "string"
-      },
-      "data_shape": {
-        "additionalProperties": false,
-        "properties": {
+  "connector_type": {
+    "id": "aws_s3_sink_0.1",
+    "kind": "ConnectorType",
+    "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_s3_sink_0.1",
+    "name": "Amazon S3 sink",
+    "version": "0.1",
+    "channels": ["stable"],
+    "description": "Send data to an Amazon S3 bucket.",
+    "icon_href": "TODO",
+    "labels": ["sink"],
+    "capabilities": ["data_shape", "error_handler", "processors"],
+    "schema": {
+      "$defs": {
+        "data_shape": {
           "consumes": {
-            "$ref": "#/$defs/data_shape/consumes"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           }
         },
-        "type": "object"
-      },
-      "error_handler": {
-        "default": {
+        "error_handler": {
+          "dead_letter_queue": {
+            "additionalProperties": false,
+            "properties": {
+              "topic": {
+                "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
+                "title": "Dead Letter Topic Name",
+                "type": "string"
+              }
+            },
+            "required": ["topic"],
+            "type": "object"
+          },
+          "log": {
+            "additionalProperties": false,
+            "type": "object"
+          },
           "stop": {
-            
+            "additionalProperties": false,
+            "type": "object"
           }
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "aws_access_key": {
+          "oneOf": [
+            {
+              "description": "The access key obtained from AWS.",
+              "format": "password",
+              "title": "Access Key",
+              "type": "string"
+            },
+            {
+              "description": "An opaque reference to the aws_access_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Access Key",
+          "x-group": "credentials"
         },
-        "oneOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "log": {
-                "$ref": "#/$defs/error_handler/log"
-              }
+        "aws_auto_create_bucket": {
+          "default": false,
+          "description": "Specifies to automatically create the S3 bucket.",
+          "title": "Autocreate Bucket",
+          "type": "boolean"
+        },
+        "aws_bucket_name_or_arn": {
+          "description": "The S3 Bucket name or Amazon Resource Name (ARN).",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "aws_key_name": {
+          "description": "The key name for saving an element in the bucket.",
+          "title": "Key Name",
+          "type": "string"
+        },
+        "aws_override_endpoint": {
+          "default": false,
+          "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
+          "title": "Endpoint Overwrite",
+          "type": "boolean"
+        },
+        "aws_region": {
+          "description": "The AWS region to access.",
+          "enum": [
+            "af-south-1",
+            "ap-east-1",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-3",
+            "ca-central-1",
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "fips-us-east-1",
+            "fips-us-east-2",
+            "fips-us-west-1",
+            "fips-us-west-2",
+            "me-south-1",
+            "sa-east-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "cn-north-1",
+            "cn-northwest-1",
+            "us-gov-east-1",
+            "us-gov-west-1",
+            "us-iso-east-1",
+            "us-iso-west-1",
+            "us-isob-east-1"
+          ],
+          "title": "AWS Region",
+          "type": "string"
+        },
+        "aws_secret_key": {
+          "oneOf": [
+            {
+              "description": "The secret key obtained from AWS.",
+              "format": "password",
+              "title": "Secret Key",
+              "type": "string"
             },
-            "required": [
-              "log"
-            ],
-            "type": "object"
+            {
+              "description": "An opaque reference to the aws_secret_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Secret Key",
+          "x-group": "credentials"
+        },
+        "aws_uri_endpoint_override": {
+          "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
+          "title": "Overwrite Endpoint URI",
+          "type": "string"
+        },
+        "data_shape": {
+          "additionalProperties": false,
+          "properties": {
+            "consumes": {
+              "$ref": "#/$defs/data_shape/consumes"
+            }
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "stop": {
-                "$ref": "#/$defs/error_handler/stop"
-              }
-            },
-            "required": [
-              "stop"
-            ],
-            "type": "object"
+          "type": "object"
+        },
+        "error_handler": {
+          "default": {
+            "stop": {}
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "dead_letter_queue": {
-                "$ref": "#/$defs/error_handler/dead_letter_queue"
-              }
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "log": {
+                  "$ref": "#/$defs/error_handler/log"
+                }
+              },
+              "required": ["log"],
+              "type": "object"
             },
-            "required": [
-              "dead_letter_queue"
-            ],
-            "type": "object"
-          }
-        ],
-        "type": "object"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "stop": {
+                  "$ref": "#/$defs/error_handler/stop"
+                }
+              },
+              "required": ["stop"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "dead_letter_queue": {
+                  "$ref": "#/$defs/error_handler/dead_letter_queue"
+                }
+              },
+              "required": ["dead_letter_queue"],
+              "type": "object"
+            }
+          ],
+          "type": "object"
+        },
+        "kafka_topic": {
+          "description": "A comma-separated list of Kafka topic names.",
+          "title": "Topic Names",
+          "type": "string"
+        },
+        "processors": {}
       },
-      "kafka_topic": {
-        "description": "A comma-separated list of Kafka topic names.",
-        "title": "Topic Names",
-        "type": "string"
-      },
-      "processors": {
-        
-      }
-    },
-    "required": [
-      "aws_bucket_name_or_arn",
-      "aws_region",
-      "kafka_topic",
-      "aws_access_key",
-      "aws_secret_key"
-    ],
-    "type": "object"
+      "required": [
+        "aws_bucket_name_or_arn",
+        "aws_region",
+        "kafka_topic",
+        "aws_access_key",
+        "aws_secret_key"
+      ],
+      "type": "object"
+    }
   }
 }

--- a/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
+++ b/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
@@ -75,6 +75,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
             ? this.t('credentialDuplicateFieldHelpText')
             : this.t('credentialEditFieldHelpText'),
         }),
+        id: name,
         labelIcon: getLabelIcon(label || name, description),
         name,
         label,
@@ -83,6 +84,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
     }
     return {
       ...props,
+      id: name,
       helperText: getExampleText(example),
       labelIcon: getLabelIcon(label || name, description),
       name,
@@ -97,6 +99,8 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
     console.log(
       'Complex type, name: ',
       name,
+      ' enumValues: ',
+      enumValues,
       ' oneOf: ',
       oneOf,
       ' field: ',

--- a/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
+++ b/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '@rhoas/app-services-ui-components';
 
 import { CustomJsonSchemaBridge } from './CustomJsonSchemaBridge';
 import './JsonSchemaConfigurator.css';
+import { TypeaheadField } from './TypeaheadField';
 
 export type CreateValidatorType = ReturnType<typeof createValidator>;
 export type ValidatorResultType = ValidateFunction<unknown>['errors'];
@@ -65,8 +66,30 @@ export const JsonSchemaConfigurator: FunctionComponent<JsonSchemaConfiguratorPro
     // no need to create form elements for error_handler, processors or steps
     const { error_handler, processors, steps, ...properties } =
       bridge.schema.properties;
-    // this is great for diagnosing form rendering problems
-    // console.log('properties: ', properties, ' configuration: ', configuration);
+    // apply global customizations across all schema based forms
+    const {
+      kafka_topic,
+      aws_access_key,
+      aws_secret_key,
+      aws_region,
+      data_shape,
+      ...otherProperties
+    } = properties;
+    // customize field components as needed
+    aws_region
+      ? (aws_region.uniforms = {
+          component: TypeaheadField,
+        })
+      : undefined;
+    // broadly organize some properties across all forms if applicable
+    const organizedProperties = {
+      ...(kafka_topic && { kafka_topic }),
+      ...(aws_access_key && { aws_access_key }),
+      ...(aws_secret_key && { aws_secret_key }),
+      ...(aws_region && { aws_region }),
+      ...otherProperties,
+      ...(data_shape && { data_shape }),
+    };
     return (
       <Grid hasGutter>
         <KameletForm
@@ -75,8 +98,8 @@ export const JsonSchemaConfigurator: FunctionComponent<JsonSchemaConfiguratorPro
           onChangeModel={(model: any) => onChangeModel(model)}
           className="connector-specific pf-c-form pf-m-9-col-on-lg"
         >
-          {Object.keys(properties).map((key) => (
-            <AutoField key={key} name={key} />
+          {Object.keys(organizedProperties).map((propertyName) => (
+            <AutoField key={propertyName} name={propertyName} />
           ))}
         </KameletForm>
       </Grid>

--- a/src/app/components/JsonSchemaConfigurator/TypeaheadField.tsx
+++ b/src/app/components/JsonSchemaConfigurator/TypeaheadField.tsx
@@ -1,0 +1,115 @@
+import React, { FC, useState } from 'react';
+import { connectField, filterDOMProps } from 'uniforms';
+
+import { AnyFunction } from 'xstate';
+
+import {
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+} from '@patternfly/react-core';
+
+export type TypeaheadProps = {
+  allowedValues: string[];
+  id: string;
+  label: string;
+  type: string;
+  disabled: boolean;
+  error: boolean;
+  errorMessage: string;
+  showInlineError: boolean;
+  help: string;
+  required: boolean;
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+function Typeahead({
+  id,
+  label,
+  type,
+  disabled,
+  error,
+  errorMessage,
+  showInlineError,
+  help,
+  required,
+  ...props
+}: TypeaheadProps) {
+  return (
+    <FormGroup
+      fieldId={id}
+      label={label}
+      isRequired={required}
+      validated={error ? 'error' : 'default'}
+      type={type}
+      helperText={help}
+      helperTextInvalid={errorMessage}
+      {...filterDOMProps(props)}
+    >
+      <TypeaheadControl {...{ id, disabled, error, ...props }} />
+    </FormGroup>
+  );
+}
+type TypeaheadFieldProps = {
+  allowedValues: string[];
+  id: string;
+  disabled: boolean;
+  error: boolean;
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  [key: string]: any;
+};
+const TypeaheadControl: FC<TypeaheadFieldProps> = ({
+  allowedValues = [],
+  id,
+  disabled,
+  error,
+  name,
+  placeholder,
+  value,
+  onChange,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <Select
+      {...filterDOMProps(props)}
+      className={'typeahead-control__select'}
+      ouiaId={name}
+      name={name}
+      isCreatable={false}
+      isDisabled={disabled}
+      variant={SelectVariant.typeahead}
+      onToggle={() => setIsOpen(!isOpen)}
+      isOpen={isOpen}
+      shouldResetOnSelect
+      placeholderText={placeholder}
+      selections={value}
+      maxHeight={400}
+      onSelect={(_, value) => {
+        const newValue =
+          typeof value === 'object'
+            ? (value as SelectOptionObject).toString()
+            : (value as string);
+        setIsOpen(false);
+        onChange(newValue);
+      }}
+      validated={error ? 'error' : 'default'}
+      inputIdPrefix={name}
+    >
+      {allowedValues
+        .filter((value) => value !== '')
+        .map((value) => (
+          <SelectOption key={value} value={value} />
+        ))}
+    </Select>
+  );
+};
+
+export const TypeaheadField = connectField<TypeaheadFieldProps>(Typeahead);

--- a/src/utils/createValidator.ts
+++ b/src/utils/createValidator.ts
@@ -6,6 +6,7 @@ const ajv = new Ajv({
   strict: 'log',
   strictSchema: false,
 });
+ajv.addVocabulary(['options', 'uniforms']);
 export function createValidator(schema: object) {
   const validator = ajv.compile(schema);
 


### PR DESCRIPTION
This change adds a method to start applying some general organization to the schema driven forms.  The kafka topic should be moved to the start of the form, and for AWS based connectors the access key/secret fields are next, followed by the region.  The other change this commit brings in is a new custom control for schema based forms to improve the AWS region selector so that it behaves more like a typeahead control and less like a select control.

![Screenshot from 2022-11-07 14-07-04](https://user-images.githubusercontent.com/351660/200398197-69d956f5-8b92-469f-ae5f-30d332247057.png)
