### PR TITLE
MGDCTRS-1153 feat: dynamic form improvements

### DIFF
--- a/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
+++ b/cypress/fixtures/connectors/aws_kinesis_source_0.1.json
@@ -1,227 +1,197 @@
 {
-  "id": "aws_kinesis_source_0.1",
-  "kind": "ConnectorType",
-  "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_kinesis_source_0.1",
-  "name": "Amazon Kinesis source",
-  "version": "0.1",
-  "channels": [
-    "stable"
-  ],
-  "description": "Receive data from Amazon Kinesis.",
-  "icon_href": "TODO",
-  "labels": [
-    "source"
-  ],
-  "capabilities": [
-    "data_shape",
-    "error_handler",
-    "processors"
-  ],
-  "schema": {
-    "$defs": {
-      "data_shape": {
-        "consumes": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        },
-        "produces": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        }
-      },
-      "error_handler": {
-        "dead_letter_queue": {
-          "additionalProperties": false,
-          "properties": {
-            "topic": {
-              "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
-              "title": "Dead Letter Topic Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "topic"
-          ],
-          "type": "object"
-        },
-        "log": {
-          "additionalProperties": false,
-          "type": "object"
-        },
-        "stop": {
-          "additionalProperties": false,
-          "type": "object"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "properties": {
-      "aws_access_key": {
-        "oneOf": [
-          {
-            "description": "The access key obtained from AWS.",
-            "format": "password",
-            "title": "Access Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_access_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Access Key",
-        "x-group": "credentials"
-      },
-      "aws_delay": {
-        "default": 500,
-        "description": "The number of milliseconds before the next poll of the selected stream.",
-        "title": "Delay",
-        "type": "integer"
-      },
-      "aws_override_endpoint": {
-        "default": false,
-        "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
-        "title": "Endpoint Overwrite",
-        "type": "boolean"
-      },
-      "aws_region": {
-        "description": "The AWS region to access.",
-        "example": "eu-west-1",
-        "title": "AWS Region",
-        "type": "string"
-      },
-      "aws_secret_key": {
-        "oneOf": [
-          {
-            "description": "The secret key obtained from AWS.",
-            "format": "password",
-            "title": "Secret Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_secret_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Secret Key",
-        "x-group": "credentials"
-      },
-      "aws_stream": {
-        "description": "The Kinesis stream that you want to access. The Kinesis stream that you specify must already exist.",
-        "title": "Stream Name",
-        "type": "string"
-      },
-      "aws_uri_endpoint_override": {
-        "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
-        "title": "Overwrite Endpoint URI",
-        "type": "string"
-      },
-      "data_shape": {
-        "additionalProperties": false,
-        "properties": {
+  "connector_type": {
+    "id": "aws_kinesis_source_0.1",
+    "kind": "ConnectorType",
+    "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_kinesis_source_0.1",
+    "name": "Amazon Kinesis source",
+    "version": "0.1",
+    "channels": ["stable"],
+    "description": "Receive data from Amazon Kinesis.",
+    "icon_href": "TODO",
+    "labels": ["source"],
+    "capabilities": ["data_shape", "error_handler", "processors"],
+    "schema": {
+      "$defs": {
+        "data_shape": {
           "consumes": {
-            "$ref": "#/$defs/data_shape/consumes"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           },
           "produces": {
-            "$ref": "#/$defs/data_shape/produces"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           }
         },
-        "type": "object"
-      },
-      "error_handler": {
-        "default": {
+        "error_handler": {
+          "dead_letter_queue": {
+            "additionalProperties": false,
+            "properties": {
+              "topic": {
+                "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
+                "title": "Dead Letter Topic Name",
+                "type": "string"
+              }
+            },
+            "required": ["topic"],
+            "type": "object"
+          },
+          "log": {
+            "additionalProperties": false,
+            "type": "object"
+          },
           "stop": {
-            
+            "additionalProperties": false,
+            "type": "object"
           }
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "aws_access_key": {
+          "oneOf": [
+            {
+              "description": "The access key obtained from AWS.",
+              "format": "password",
+              "title": "Access Key",
+              "type": "string"
+            },
+            {
+              "description": "An opaque reference to the aws_access_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Access Key",
+          "x-group": "credentials"
         },
-        "oneOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "log": {
-                "$ref": "#/$defs/error_handler/log"
-              }
+        "aws_delay": {
+          "default": 500,
+          "description": "The number of milliseconds before the next poll of the selected stream.",
+          "title": "Delay",
+          "type": "integer"
+        },
+        "aws_override_endpoint": {
+          "default": false,
+          "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
+          "title": "Endpoint Overwrite",
+          "type": "boolean"
+        },
+        "aws_region": {
+          "description": "The AWS region to access.",
+          "example": "eu-west-1",
+          "title": "AWS Region",
+          "type": "string"
+        },
+        "aws_secret_key": {
+          "oneOf": [
+            {
+              "description": "The secret key obtained from AWS.",
+              "format": "password",
+              "title": "Secret Key",
+              "type": "string"
             },
-            "required": [
-              "log"
-            ],
-            "type": "object"
+            {
+              "description": "An opaque reference to the aws_secret_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Secret Key",
+          "x-group": "credentials"
+        },
+        "aws_stream": {
+          "description": "The Kinesis stream that you want to access. The Kinesis stream that you specify must already exist.",
+          "title": "Stream Name",
+          "type": "string"
+        },
+        "aws_uri_endpoint_override": {
+          "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
+          "title": "Overwrite Endpoint URI",
+          "type": "string"
+        },
+        "data_shape": {
+          "additionalProperties": false,
+          "properties": {
+            "consumes": {
+              "$ref": "#/$defs/data_shape/consumes"
+            },
+            "produces": {
+              "$ref": "#/$defs/data_shape/produces"
+            }
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "stop": {
-                "$ref": "#/$defs/error_handler/stop"
-              }
-            },
-            "required": [
-              "stop"
-            ],
-            "type": "object"
+          "type": "object"
+        },
+        "error_handler": {
+          "default": {
+            "stop": {}
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "dead_letter_queue": {
-                "$ref": "#/$defs/error_handler/dead_letter_queue"
-              }
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "log": {
+                  "$ref": "#/$defs/error_handler/log"
+                }
+              },
+              "required": ["log"],
+              "type": "object"
             },
-            "required": [
-              "dead_letter_queue"
-            ],
-            "type": "object"
-          }
-        ],
-        "type": "object"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "stop": {
+                  "$ref": "#/$defs/error_handler/stop"
+                }
+              },
+              "required": ["stop"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "dead_letter_queue": {
+                  "$ref": "#/$defs/error_handler/dead_letter_queue"
+                }
+              },
+              "required": ["dead_letter_queue"],
+              "type": "object"
+            }
+          ],
+          "type": "object"
+        },
+        "kafka_topic": {
+          "description": "The name of the Kafka Topic to use.",
+          "title": "Topic Name",
+          "type": "string"
+        },
+        "processors": {}
       },
-      "kafka_topic": {
-        "description": "The name of the Kafka Topic to use.",
-        "title": "Topic Name",
-        "type": "string"
-      },
-      "processors": {
-        
-      }
-    },
-    "required": [
-      "aws_stream",
-      "aws_region",
-      "kafka_topic",
-      "aws_access_key",
-      "aws_secret_key"
-    ],
-    "type": "object"
+      "required": [
+        "aws_stream",
+        "aws_region",
+        "kafka_topic",
+        "aws_access_key",
+        "aws_secret_key"
+      ],
+      "type": "object"
+    }
   }
 }

--- a/cypress/fixtures/connectors/aws_s3_sink_0.1.json
+++ b/cypress/fixtures/connectors/aws_s3_sink_0.1.json
@@ -1,246 +1,220 @@
 {
-  "id": "aws_s3_sink_0.1",
-  "kind": "ConnectorType",
-  "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_s3_sink_0.1",
-  "name": "Amazon S3 sink",
-  "version": "0.1",
-  "channels": [
-    "stable"
-  ],
-  "description": "Send data to an Amazon S3 bucket.",
-  "icon_href": "TODO",
-  "labels": [
-    "sink"
-  ],
-  "capabilities": [
-    "data_shape",
-    "error_handler",
-    "processors"
-  ],
-  "schema": {
-    "$defs": {
-      "data_shape": {
-        "consumes": {
-          "additionalProperties": false,
-          "properties": {
-            "format": {
-              "default": "application/octet-stream",
-              "description": "The format of the data that the source connector sends to Kafka.",
-              "enum": [
-                "application/octet-stream"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "format"
-          ],
-          "type": "object"
-        }
-      },
-      "error_handler": {
-        "dead_letter_queue": {
-          "additionalProperties": false,
-          "properties": {
-            "topic": {
-              "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
-              "title": "Dead Letter Topic Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "topic"
-          ],
-          "type": "object"
-        },
-        "log": {
-          "additionalProperties": false,
-          "type": "object"
-        },
-        "stop": {
-          "additionalProperties": false,
-          "type": "object"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "properties": {
-      "aws_access_key": {
-        "oneOf": [
-          {
-            "description": "The access key obtained from AWS.",
-            "format": "password",
-            "title": "Access Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_access_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Access Key",
-        "x-group": "credentials"
-      },
-      "aws_auto_create_bucket": {
-        "default": false,
-        "description": "Specifies to automatically create the S3 bucket.",
-        "title": "Autocreate Bucket",
-        "type": "boolean"
-      },
-      "aws_bucket_name_or_arn": {
-        "description": "The S3 Bucket name or Amazon Resource Name (ARN).",
-        "title": "Bucket Name",
-        "type": "string"
-      },
-      "aws_key_name": {
-        "description": "The key name for saving an element in the bucket.",
-        "title": "Key Name",
-        "type": "string"
-      },
-      "aws_override_endpoint": {
-        "default": false,
-        "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
-        "title": "Endpoint Overwrite",
-        "type": "boolean"
-      },
-      "aws_region": {
-        "description": "The AWS region to access.",
-        "enum": [
-          "af-south-1",
-          "ap-east-1",
-          "ap-northeast-1",
-          "ap-northeast-2",
-          "ap-northeast-3",
-          "ap-south-1",
-          "ap-southeast-1",
-          "ap-southeast-2",
-          "ap-southeast-3",
-          "ca-central-1",
-          "eu-central-1",
-          "eu-north-1",
-          "eu-south-1",
-          "eu-west-1",
-          "eu-west-2",
-          "eu-west-3",
-          "fips-us-east-1",
-          "fips-us-east-2",
-          "fips-us-west-1",
-          "fips-us-west-2",
-          "me-south-1",
-          "sa-east-1",
-          "us-east-1",
-          "us-east-2",
-          "us-west-1",
-          "us-west-2",
-          "cn-north-1",
-          "cn-northwest-1",
-          "us-gov-east-1",
-          "us-gov-west-1",
-          "us-iso-east-1",
-          "us-iso-west-1",
-          "us-isob-east-1"
-        ],
-        "title": "AWS Region",
-        "type": "string"
-      },
-      "aws_secret_key": {
-        "oneOf": [
-          {
-            "description": "The secret key obtained from AWS.",
-            "format": "password",
-            "title": "Secret Key",
-            "type": "string"
-          },
-          {
-            "description": "An opaque reference to the aws_secret_key",
-            "properties": {
-              
-            },
-            "type": "object"
-          }
-        ],
-        "title": "Secret Key",
-        "x-group": "credentials"
-      },
-      "aws_uri_endpoint_override": {
-        "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
-        "title": "Overwrite Endpoint URI",
-        "type": "string"
-      },
-      "data_shape": {
-        "additionalProperties": false,
-        "properties": {
+  "connector_type": {
+    "id": "aws_s3_sink_0.1",
+    "kind": "ConnectorType",
+    "href": "/api/connector_mgmt/v1/kafka_connector_types/aws_s3_sink_0.1",
+    "name": "Amazon S3 sink",
+    "version": "0.1",
+    "channels": ["stable"],
+    "description": "Send data to an Amazon S3 bucket.",
+    "icon_href": "TODO",
+    "labels": ["sink"],
+    "capabilities": ["data_shape", "error_handler", "processors"],
+    "schema": {
+      "$defs": {
+        "data_shape": {
           "consumes": {
-            "$ref": "#/$defs/data_shape/consumes"
+            "additionalProperties": false,
+            "properties": {
+              "format": {
+                "default": "application/octet-stream",
+                "description": "The format of the data that the source connector sends to Kafka.",
+                "enum": ["application/octet-stream"],
+                "type": "string"
+              }
+            },
+            "required": ["format"],
+            "type": "object"
           }
         },
-        "type": "object"
-      },
-      "error_handler": {
-        "default": {
+        "error_handler": {
+          "dead_letter_queue": {
+            "additionalProperties": false,
+            "properties": {
+              "topic": {
+                "description": "The name of the Kafka topic that serves as a destination for messages which were not processed correctly due to an error.",
+                "title": "Dead Letter Topic Name",
+                "type": "string"
+              }
+            },
+            "required": ["topic"],
+            "type": "object"
+          },
+          "log": {
+            "additionalProperties": false,
+            "type": "object"
+          },
           "stop": {
-            
+            "additionalProperties": false,
+            "type": "object"
           }
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "aws_access_key": {
+          "oneOf": [
+            {
+              "description": "The access key obtained from AWS.",
+              "format": "password",
+              "title": "Access Key",
+              "type": "string"
+            },
+            {
+              "description": "An opaque reference to the aws_access_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Access Key",
+          "x-group": "credentials"
         },
-        "oneOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "log": {
-                "$ref": "#/$defs/error_handler/log"
-              }
+        "aws_auto_create_bucket": {
+          "default": false,
+          "description": "Specifies to automatically create the S3 bucket.",
+          "title": "Autocreate Bucket",
+          "type": "boolean"
+        },
+        "aws_bucket_name_or_arn": {
+          "description": "The S3 Bucket name or Amazon Resource Name (ARN).",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "aws_key_name": {
+          "description": "The key name for saving an element in the bucket.",
+          "title": "Key Name",
+          "type": "string"
+        },
+        "aws_override_endpoint": {
+          "default": false,
+          "description": "Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.",
+          "title": "Endpoint Overwrite",
+          "type": "boolean"
+        },
+        "aws_region": {
+          "description": "The AWS region to access.",
+          "enum": [
+            "af-south-1",
+            "ap-east-1",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-3",
+            "ca-central-1",
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "fips-us-east-1",
+            "fips-us-east-2",
+            "fips-us-west-1",
+            "fips-us-west-2",
+            "me-south-1",
+            "sa-east-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "cn-north-1",
+            "cn-northwest-1",
+            "us-gov-east-1",
+            "us-gov-west-1",
+            "us-iso-east-1",
+            "us-iso-west-1",
+            "us-isob-east-1"
+          ],
+          "title": "AWS Region",
+          "type": "string"
+        },
+        "aws_secret_key": {
+          "oneOf": [
+            {
+              "description": "The secret key obtained from AWS.",
+              "format": "password",
+              "title": "Secret Key",
+              "type": "string"
             },
-            "required": [
-              "log"
-            ],
-            "type": "object"
+            {
+              "description": "An opaque reference to the aws_secret_key",
+              "properties": {},
+              "type": "object"
+            }
+          ],
+          "title": "Secret Key",
+          "x-group": "credentials"
+        },
+        "aws_uri_endpoint_override": {
+          "description": "The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.",
+          "title": "Overwrite Endpoint URI",
+          "type": "string"
+        },
+        "data_shape": {
+          "additionalProperties": false,
+          "properties": {
+            "consumes": {
+              "$ref": "#/$defs/data_shape/consumes"
+            }
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "stop": {
-                "$ref": "#/$defs/error_handler/stop"
-              }
-            },
-            "required": [
-              "stop"
-            ],
-            "type": "object"
+          "type": "object"
+        },
+        "error_handler": {
+          "default": {
+            "stop": {}
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "dead_letter_queue": {
-                "$ref": "#/$defs/error_handler/dead_letter_queue"
-              }
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "log": {
+                  "$ref": "#/$defs/error_handler/log"
+                }
+              },
+              "required": ["log"],
+              "type": "object"
             },
-            "required": [
-              "dead_letter_queue"
-            ],
-            "type": "object"
-          }
-        ],
-        "type": "object"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "stop": {
+                  "$ref": "#/$defs/error_handler/stop"
+                }
+              },
+              "required": ["stop"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "dead_letter_queue": {
+                  "$ref": "#/$defs/error_handler/dead_letter_queue"
+                }
+              },
+              "required": ["dead_letter_queue"],
+              "type": "object"
+            }
+          ],
+          "type": "object"
+        },
+        "kafka_topic": {
+          "description": "A comma-separated list of Kafka topic names.",
+          "title": "Topic Names",
+          "type": "string"
+        },
+        "processors": {}
       },
-      "kafka_topic": {
-        "description": "A comma-separated list of Kafka topic names.",
-        "title": "Topic Names",
-        "type": "string"
-      },
-      "processors": {
-        
-      }
-    },
-    "required": [
-      "aws_bucket_name_or_arn",
-      "aws_region",
-      "kafka_topic",
-      "aws_access_key",
-      "aws_secret_key"
-    ],
-    "type": "object"
+      "required": [
+        "aws_bucket_name_or_arn",
+        "aws_region",
+        "kafka_topic",
+        "aws_access_key",
+        "aws_secret_key"
+      ],
+      "type": "object"
+    }
   }
 }

--- a/cypress/fixtures/connectors/debezium-postgres-1.9.4.Alpha1.json
+++ b/cypress/fixtures/connectors/debezium-postgres-1.9.4.Alpha1.json
@@ -1,30 +1,19 @@
 {
+  "connector_type": {
     "id": "debezium-postgres-1.9.4.Final",
     "kind": "ConnectorType",
     "href": "/api/connector_mgmt/v1/kafka_connector_types/debezium-postgres-1.9.4.Final",
     "name": "Debezium PostgreSQL Connector",
     "version": "1.9.4.Final",
-    "channels": [
-      "stable"
-    ],
+    "channels": ["stable"],
     "icon_href": "http://example.com/images/debezium-postgres-1.9.4.Final.png",
-    "labels": [
-      "1.9.4.Final",
-      "debezium",
-      "postgres",
-      "source"
-    ],
-    "capabilities": [
-      "data_shape"
-    ],
+    "labels": ["1.9.4.Final", "debezium", "postgres", "source"],
+    "capabilities": ["data_shape"],
     "schema": {
       "$defs": {
         "serializer": {
           "default": "JSON",
-          "enum": [
-            "JSON",
-            "JSON without schema"
-          ],
+          "enum": ["JSON", "JSON without schema"],
           "type": "string"
         }
       },
@@ -93,9 +82,7 @@
             {
               "additionalProperties": true,
               "description": "An opaque reference to the password.",
-              "properties": {
-                
-              },
+              "properties": {},
               "type": "object"
             }
           ],
@@ -131,11 +118,7 @@
         "decimal.handling.mode": {
           "default": "precise",
           "description": "Specify how DECIMAL and NUMERIC columns should be represented in change events, including:'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; 'string' uses string to represent values; 'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.",
-          "enum": [
-            "string",
-            "double",
-            "precise"
-          ],
+          "enum": ["string", "double", "precise"],
           "title": "Decimal Handling",
           "type": "string",
           "x-category": "CONNECTOR",
@@ -169,11 +152,7 @@
         "publication.autocreate.mode": {
           "default": "all_tables",
           "description": "Applies only when streaming changes using pgoutput.Determine how creation of a publication should work, the default is all_tables.DISABLED - The connector will not attempt to create a publication at all. The expectation is that the user has created the publication up-front. If the publication isn't found to exist upon startup, the connector will throw an exception and stop.ALL_TABLES - If no publication exists, the connector will create a new publication for all tables. Note this requires that the configured user has access. If the publication already exists, it will be used. i.e CREATE PUBLICATION \u003cpublication_name\u003e FOR ALL TABLES;FILTERED - If no publication exists, the connector will create a new publication for all those tables matchingthe current filter configuration (see table/database include/exclude list properties). If the publication already exists, it will be used. i.e CREATE PUBLICATION \u003cpublication_name\u003e FOR TABLE \u003ctbl1, tbl2, etc\u003e",
-          "enum": [
-            "filtered",
-            "disabled",
-            "all_tables"
-          ],
+          "enum": ["filtered", "disabled", "all_tables"],
           "title": "Publication Auto Create Mode",
           "type": "string",
           "x-category": "CONNECTION_ADVANCED_REPLICATION",
@@ -266,3 +245,4 @@
       "x-version": "1.9.4.Final"
     }
   }
+}

--- a/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
+++ b/src/app/components/JsonSchemaConfigurator/CustomJsonSchemaBridge.tsx
@@ -75,6 +75,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
             ? this.t('credentialDuplicateFieldHelpText')
             : this.t('credentialEditFieldHelpText'),
         }),
+        id: name,
         labelIcon: getLabelIcon(label || name, description),
         name,
         label,
@@ -83,6 +84,7 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
     }
     return {
       ...props,
+      id: name,
       helperText: getExampleText(example),
       labelIcon: getLabelIcon(label || name, description),
       name,
@@ -97,6 +99,8 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
     console.log(
       'Complex type, name: ',
       name,
+      ' enumValues: ',
+      enumValues,
       ' oneOf: ',
       oneOf,
       ' field: ',

--- a/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
+++ b/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.tsx
@@ -1,5 +1,8 @@
 import { createValidator } from '@utils/createValidator';
-import { clearEmptyObjectValues } from '@utils/shared';
+import {
+  applyClientSideFormCustomizations,
+  clearEmptyObjectValues,
+} from '@utils/shared';
 import { ValidateFunction } from 'ajv';
 import _ from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -12,6 +15,7 @@ import { useTranslation } from '@rhoas/app-services-ui-components';
 
 import { CustomJsonSchemaBridge } from './CustomJsonSchemaBridge';
 import './JsonSchemaConfigurator.css';
+import { TypeaheadField } from './TypeaheadField';
 
 export type CreateValidatorType = ReturnType<typeof createValidator>;
 export type ValidatorResultType = ValidateFunction<unknown>['errors'];
@@ -65,8 +69,17 @@ export const JsonSchemaConfigurator: FunctionComponent<JsonSchemaConfiguratorPro
     // no need to create form elements for error_handler, processors or steps
     const { error_handler, processors, steps, ...properties } =
       bridge.schema.properties;
-    // this is great for diagnosing form rendering problems
-    // console.log('properties: ', properties, ' configuration: ', configuration);
+    // customize field components as needed
+    const { aws_region, ...otherProperties } = properties;
+    aws_region && aws_region.enum
+      ? (aws_region.uniforms = {
+          component: TypeaheadField,
+        })
+      : undefined;
+    const organizedProperties = applyClientSideFormCustomizations({
+      ...otherProperties,
+      ...(aws_region && { aws_region }),
+    });
     return (
       <Grid hasGutter>
         <KameletForm
@@ -75,8 +88,8 @@ export const JsonSchemaConfigurator: FunctionComponent<JsonSchemaConfiguratorPro
           onChangeModel={(model: any) => onChangeModel(model)}
           className="connector-specific pf-c-form pf-m-9-col-on-lg"
         >
-          {Object.keys(properties).map((key) => (
-            <AutoField key={key} name={key} />
+          {Object.keys(organizedProperties).map((propertyName) => (
+            <AutoField key={propertyName} name={propertyName} />
           ))}
         </KameletForm>
       </Grid>

--- a/src/app/components/JsonSchemaConfigurator/TypeaheadField.tsx
+++ b/src/app/components/JsonSchemaConfigurator/TypeaheadField.tsx
@@ -1,0 +1,108 @@
+import React, { FC, useState } from 'react';
+import { connectField, filterDOMProps } from 'uniforms';
+
+import {
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+} from '@patternfly/react-core';
+
+export type TypeaheadProps = {
+  allowedValues: string[];
+  id: string;
+  disabled: boolean;
+  error: boolean;
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  [key: string]: any;
+};
+function Typeahead({
+  id,
+  label,
+  type,
+  disabled,
+  error,
+  errorMessage,
+  showInlineError,
+  help,
+  required,
+  ...props
+}: TypeaheadProps) {
+  return (
+    <FormGroup
+      fieldId={id}
+      label={label}
+      isRequired={required}
+      validated={error ? 'error' : 'default'}
+      type={type}
+      helperText={help}
+      helperTextInvalid={errorMessage}
+      {...filterDOMProps(props)}
+    >
+      <TypeaheadControl {...{ id, disabled, error, ...props }} />
+    </FormGroup>
+  );
+}
+type TypeaheadFieldProps = {
+  allowedValues: string[];
+  id: string;
+  disabled: boolean;
+  error: boolean;
+  name: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  [key: string]: any;
+};
+const TypeaheadControl: FC<TypeaheadFieldProps> = ({
+  allowedValues = [],
+  id,
+  disabled,
+  error,
+  name,
+  placeholder,
+  value,
+  onChange,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <Select
+      {...filterDOMProps(props)}
+      className={'typeahead-control__select'}
+      ouiaId={name}
+      name={name}
+      isCreatable={false}
+      isDisabled={disabled}
+      variant={SelectVariant.typeahead}
+      onToggle={() => setIsOpen(!isOpen)}
+      isOpen={isOpen}
+      shouldResetOnSelect
+      placeholderText={placeholder}
+      selections={value}
+      maxHeight={400}
+      onSelect={(_, value) => {
+        const newValue =
+          typeof value === 'object'
+            ? (value as SelectOptionObject).toString()
+            : (value as string);
+        setIsOpen(false);
+        onChange(newValue);
+      }}
+      validated={error ? 'error' : 'default'}
+      inputIdPrefix={name}
+    >
+      {allowedValues
+        .filter((value) => value !== '')
+        .map((value) => (
+          <SelectOption key={value} value={value} />
+        ))}
+    </Select>
+  );
+};
+
+export const TypeaheadField = connectField<TypeaheadFieldProps>(Typeahead);

--- a/src/app/components/ViewJSONFormat/ViewJSONFormat.stories.tsx
+++ b/src/app/components/ViewJSONFormat/ViewJSONFormat.stories.tsx
@@ -88,7 +88,7 @@ export const JSON_View = Template.bind({});
 JSON_View.args = {
   kafka: kafka_instance_test,
   namespace: namespace_test,
-  connectorType: aws_s3_sink,
+  connectorType: aws_s3_sink.connector_type,
   name: 'test',
   topic: undefined,
   userErrorHandler: 'stop',

--- a/src/app/pages/ConnectorDetailsPage/components/ConfigurationTab/ConfigurationStep.tsx
+++ b/src/app/pages/ConnectorDetailsPage/components/ConfigurationTab/ConfigurationStep.tsx
@@ -1,6 +1,7 @@
 import { JsonSchemaConfigurator } from '@app/components/JsonSchemaConfigurator/JsonSchemaConfigurator';
 import { StepBodyLayout } from '@app/components/StepBodyLayout/StepBodyLayout';
 import {
+  applyClientSideFormCustomizations,
   clearEmptyObjectValues,
   patchConfigurationObject,
 } from '@utils/shared';
@@ -121,7 +122,7 @@ export const ConfigurationStep: FC<ConfigurationStepProps> = ({
         />
       ) : (
         <Form>
-          {Object.entries(schema.properties)
+          {Object.entries(applyClientSideFormCustomizations(schema.properties))
             .filter(([key, value]: [string, any]) => {
               if (['object', 'array'].includes(value.type)) {
                 if (key === 'data_shape' && formConfiguration[key]) {

--- a/src/app/pages/CreateConnectorPage/StepReview.stories.tsx
+++ b/src/app/pages/CreateConnectorPage/StepReview.stories.tsx
@@ -90,7 +90,7 @@ export const Default = Template.bind({});
 Default.args = {
   kafka: kafka_instance_test,
   namespace: namespace_test,
-  connectorType: aws_s3_sink,
+  connectorType: aws_s3_sink.connector_type,
   name: 'test',
   topic: undefined,
   userErrorHandler: 'stop',
@@ -107,7 +107,7 @@ export const WithDLQErrorHandling = Template.bind({});
 WithDLQErrorHandling.args = {
   kafka: kafka_instance_test,
   namespace: namespace_test,
-  connectorType: aws_s3_sink,
+  connectorType: aws_s3_sink.connector_type,
   name: 'test',
   topic: 'Dead_letter_topic_name',
   userErrorHandler: 'dead_letter_queue',
@@ -124,7 +124,7 @@ export const WithDataShapeConsumesAndProduces = Template.bind({});
 WithDataShapeConsumesAndProduces.args = {
   kafka: kafka_instance_test,
   namespace: namespace_test,
-  connectorType: aws_kinesis_source,
+  connectorType: aws_kinesis_source.connector_type,
   name: 'test',
   topic: 'Dead_letter_topic_name',
   userErrorHandler: 'dead_letter_queue',
@@ -141,7 +141,7 @@ export const ForDebeziumConnector = Template.bind({});
 ForDebeziumConnector.args = {
   kafka: kafka_instance_test,
   namespace: namespace_test,
-  connectorType: debezium_postgres,
+  connectorType: debezium_postgres.connector_type,
   name: 'test',
   topic: undefined,
   userErrorHandler: undefined,

--- a/src/utils/createValidator.ts
+++ b/src/utils/createValidator.ts
@@ -6,6 +6,7 @@ const ajv = new Ajv({
   strict: 'log',
   strictSchema: false,
 });
+ajv.addVocabulary(['options', 'uniforms']);
 export function createValidator(schema: object) {
   const validator = ajv.compile(schema);
 

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -169,3 +169,29 @@ export const patchConfigurationObject = (
   }
   return configuration;
 };
+
+/**
+ * Applies general tweaks to the form configuration received from the server
+ * to try and organize the fields a little better
+ * @param properties
+ * @returns
+ */
+export const applyClientSideFormCustomizations = (properties: any) => {
+  const {
+    kafka_topic,
+    aws_access_key,
+    aws_secret_key,
+    aws_region,
+    data_shape,
+    ...otherProperties
+  } = properties;
+  const organizedProperties = {
+    ...(kafka_topic && { kafka_topic }),
+    ...(aws_access_key && { aws_access_key }),
+    ...(aws_secret_key && { aws_secret_key }),
+    ...(aws_region && { aws_region }),
+    ...otherProperties,
+    ...(data_shape && { data_shape }),
+  };
+  return organizedProperties;
+};


### PR DESCRIPTION
This change adds a method to start applying some general organization to the schema driven forms.  The kafka topic should be moved to the start of the form, and for AWS based connectors the access key/secret fields are next, followed by the region.  The other change this commit brings in is a new custom control for schema based forms to improve the AWS region selector so that it behaves more like a typeahead control and less like a select control.

![Screenshot from 2022-11-07 14-07-04](https://user-images.githubusercontent.com/351660/200398673-af3a87f5-fa63-479a-8558-9e6cc95b2591.png)
