### PR TITLE
MGDCTRS-1438 fix: add some margin under the table

### DIFF
--- a/src/app/pages/ConnectorsPage/ConnectorsPage.stories.tsx
+++ b/src/app/pages/ConnectorsPage/ConnectorsPage.stories.tsx
@@ -65,6 +65,20 @@ WithConnectors.parameters = {
   ],
 };
 
+export const WithOneConnector = Template.bind({});
+WithOneConnector.parameters = {
+  msw: [
+    rest.get(GET_CONNECTORS_API, (req, res, ctx) => {
+      const searchParams = req.url.searchParams;
+      const page = +(searchParams.get('page') || 1);
+      const size = +(searchParams.get('size') || 20);
+      const search = searchParams.get('search') || '';
+      const response = generateStoryConnectorInstances(page, size, search, 1);
+      return res(ctx.delay(), ctx.json(response));
+    }),
+  ],
+};
+
 export const WithLotsOfConnectors = Template.bind({});
 WithLotsOfConnectors.parameters = {
   msw: [

--- a/src/app/pages/ConnectorsPage/components/ConnectorActions/ConnectorActions.tsx
+++ b/src/app/pages/ConnectorsPage/components/ConnectorActions/ConnectorActions.tsx
@@ -99,6 +99,7 @@ export const ConnectorActions: FunctionComponent<ConnectorActionsProps> = ({
       <ActionsColumn
         items={actions}
         isDisabled={connector.desired_state === ConnectorDesiredState.Deleted}
+        rowData={{ actionProps: { menuAppendTo: document.body } }}
         data-testid={`actions-for-${id!}`}
       />
     </>

--- a/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.css
+++ b/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.css
@@ -1,0 +1,3 @@
+.connector-instances-table__wrapper .pf-c-scroll-outer-wrapper {
+  margin-bottom: 10em;
+}

--- a/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.tsx
+++ b/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.tsx
@@ -12,6 +12,7 @@ import { Connector } from '@rhoas/connector-management-sdk';
 import { CONNECTOR_INSTANCES_COLUMNS } from '../../constants';
 import { ConnectorActions } from '../ConnectorActions/ConnectorActions';
 import { ConnectorCell } from '../ConnectorCell/ConnectorCell';
+import './ConnectorInstancesTable.css';
 
 export type ConnectorInstancesTableProps = {
   activeSortColumn: string;
@@ -64,94 +65,96 @@ export const ConnectorInstancesTable: FunctionComponent<ConnectorInstancesTableP
       state: t('status'),
     } as { [key in typeof CONNECTOR_INSTANCES_COLUMNS[number]]: string };
     return (
-      <TableView
-        ariaLabel="Sortable Connectors Instance Table"
-        columns={CONNECTOR_INSTANCES_COLUMNS}
-        data={items}
-        renderHeader={({ column, Th, key }) => (
-          <Th
-            key={key}
-            sort={{
-              sortBy: {
-                index:
-                  CONNECTOR_INSTANCES_COLUMNS.indexOf(
-                    activeSortColumn as typeof CONNECTOR_INSTANCES_COLUMNS[number]
-                  ) || 0,
-                direction: (activeSortDirection as 'asc') || 'desc',
-                defaultDirection: 'asc',
-              },
-              onSort: (_event, index, direction) =>
-                onSort({ [CONNECTOR_INSTANCES_COLUMNS[index]]: direction }),
-              columnIndex: CONNECTOR_INSTANCES_COLUMNS.indexOf(column),
-            }}
-          >
-            {columnLabels[column]}
-          </Th>
-        )}
-        renderActions={({ row, ActionsColumn }) => (
-          <ConnectorActions
-            ActionsColumn={ActionsColumn}
-            connectorRef={row}
-            onConnectorDetail={onConnectorDetail}
-            onDuplicateConnector={onDuplicateConnector}
-          />
-        )}
-        renderCell={({ column, row, key, Td }) => (
-          <ConnectorCell
-            key={key}
-            Td={Td}
-            column={column}
-            columnLabels={columnLabels}
-            tdKey={key}
-            connectorRef={row}
-            onConnectorDetail={onConnectorDetail}
-          />
-        )}
-        onRowClick={({ row }) => row.send('connector.select')}
-        isRowSelected={({ row }) =>
-          selectedConnector
-            ? selectedConnector.id === row.getSnapshot()?.context.connector.id
-            : false
-        }
-        setActionCellOuiaId={({ row }) =>
-          `actions-for-${row.getSnapshot()?.context.connector.id}`
-        }
-        toolbarBreakpoint={'lg'}
-        filters={{
-          name: {
-            type: 'search',
-            chips: namesChips,
-            onSearch: onSearchName,
-            onRemoveChip: onRemoveNameChip,
-            onRemoveGroup: onRemoveNameChipGroup,
-            validate: (_val) => true,
-            errorMessage: t('input_field_invalid_message'),
-          },
-        }}
-        tools={[
-          <NavLink
-            className="pf-c-button pf-m-primary"
-            to={'/create-connector'}
-            data-ouia-component-id={'button-create'}
-          >
-            {t('createConnectorsInstance')}
-          </NavLink>,
-        ]}
-        itemCount={itemCount}
-        page={page}
-        perPage={size}
-        onClearAllFilters={onClearAllFilters}
-        isFiltered={isFiltered}
-        onPageChange={onPageChange}
-        emptyStateNoData={
-          <EmptyStateGettingStarted
-            onCreate={onCreateConnector}
-            onHelp={onHelp}
-          />
-        }
-        emptyStateNoResults={
-          <EmptyStateNoMatchesFound onClear={onClearAllFilters} />
-        }
-      />
+      <div className={'connector-instances-table__wrapper'}>
+        <TableView
+          ariaLabel="Sortable Connectors Instance Table"
+          columns={CONNECTOR_INSTANCES_COLUMNS}
+          data={items}
+          renderHeader={({ column, Th, key }) => (
+            <Th
+              key={key}
+              sort={{
+                sortBy: {
+                  index:
+                    CONNECTOR_INSTANCES_COLUMNS.indexOf(
+                      activeSortColumn as typeof CONNECTOR_INSTANCES_COLUMNS[number]
+                    ) || 0,
+                  direction: (activeSortDirection as 'asc') || 'desc',
+                  defaultDirection: 'asc',
+                },
+                onSort: (_event, index, direction) =>
+                  onSort({ [CONNECTOR_INSTANCES_COLUMNS[index]]: direction }),
+                columnIndex: CONNECTOR_INSTANCES_COLUMNS.indexOf(column),
+              }}
+            >
+              {columnLabels[column]}
+            </Th>
+          )}
+          renderActions={({ row, ActionsColumn }) => (
+            <ConnectorActions
+              ActionsColumn={ActionsColumn}
+              connectorRef={row}
+              onConnectorDetail={onConnectorDetail}
+              onDuplicateConnector={onDuplicateConnector}
+            />
+          )}
+          renderCell={({ column, row, key, Td }) => (
+            <ConnectorCell
+              key={key}
+              Td={Td}
+              column={column}
+              columnLabels={columnLabels}
+              tdKey={key}
+              connectorRef={row}
+              onConnectorDetail={onConnectorDetail}
+            />
+          )}
+          onRowClick={({ row }) => row.send('connector.select')}
+          isRowSelected={({ row }) =>
+            selectedConnector
+              ? selectedConnector.id === row.getSnapshot()?.context.connector.id
+              : false
+          }
+          setActionCellOuiaId={({ row }) =>
+            `actions-for-${row.getSnapshot()?.context.connector.id}`
+          }
+          toolbarBreakpoint={'lg'}
+          filters={{
+            name: {
+              type: 'search',
+              chips: namesChips,
+              onSearch: onSearchName,
+              onRemoveChip: onRemoveNameChip,
+              onRemoveGroup: onRemoveNameChipGroup,
+              validate: (_val) => true,
+              errorMessage: t('input_field_invalid_message'),
+            },
+          }}
+          tools={[
+            <NavLink
+              className="pf-c-button pf-m-primary"
+              to={'/create-connector'}
+              data-ouia-component-id={'button-create'}
+            >
+              {t('createConnectorsInstance')}
+            </NavLink>,
+          ]}
+          itemCount={itemCount}
+          page={page}
+          perPage={size}
+          onClearAllFilters={onClearAllFilters}
+          isFiltered={isFiltered}
+          onPageChange={onPageChange}
+          emptyStateNoData={
+            <EmptyStateGettingStarted
+              onCreate={onCreateConnector}
+              onHelp={onHelp}
+            />
+          }
+          emptyStateNoResults={
+            <EmptyStateNoMatchesFound onClear={onClearAllFilters} />
+          }
+        />
+      </div>
     );
   };


### PR DESCRIPTION
This change adds back in the workaround to attach an instance's actions to the document body and adds some margin underneath the table so that the page is hopefully tall enough to accommodate the action menu for even the last instance.