### PR TITLE
MGDCTRS-1622 fix: respond to external nav events

### DIFF
--- a/src/AppFederated.tsx
+++ b/src/AppFederated.tsx
@@ -2,7 +2,12 @@ import { Loading } from '@app/components/Loading/Loading';
 import { AnalyticsProvider } from '@hooks/useAnalytics';
 import i18n from '@i18n/i18n';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import React, { FunctionComponent } from 'react';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import { I18nextProvider } from '@rhoas/app-services-ui-components';
@@ -23,9 +28,29 @@ export const AppFederated: FunctionComponent = () => {
   const config = useConfig();
   const auth = useAuth();
   const basename = useBasename();
+  const [key, setKey] = useState(0);
   const { analytics } = useChrome() as {
     analytics: { track: (event: string, properties: unknown) => void };
   };
+  const bumpKey = useCallback(() => {
+    setKey(key + 1);
+  }, [key, setKey]);
+  // force our router instance to refresh it's history state when there's a
+  // side navigation event
+  useEffect(() => {
+    const insights = window['insights'];
+    const unregister =
+      insights && insights.chrome
+        ? insights.chrome.on('APP_NAVIGATION', (event) => {
+            if (event.navId === 'connectors') {
+              bumpKey();
+            }
+          })
+        : () => {};
+    return () => {
+      unregister!();
+    };
+  });
   return (
     <I18nextProvider i18n={i18n}>
       <AnalyticsProvider
@@ -34,7 +59,7 @@ export const AppFederated: FunctionComponent = () => {
         }
       >
         <React.Suspense fallback={<Loading />}>
-          <Router basename={basename?.getBasename()}>
+          <Router basename={basename?.getBasename()} key={key}>
             <CosRoutes
               getToken={async () => (await auth?.kas.getToken()) || ''}
               connectorsApiBasePath={config?.cos.apiBasePath || ''}


### PR DESCRIPTION
This change adds a handler to receive insights app navigation events so that we can ensure the app handles external changes to the window history that our app's router doesn't currently capture.

Note this needs to be tested in federated mode, easiest way to reproduce is go to the detail page for a connector and then click the main navigation link for "Connectors", without this fix the app will appear to reload but stay on the detail page.