### PR TITLE
MGDCTRS-1524:fix:Selecting KI immediately after creating it won't work

### DIFF
--- a/src/app/machines/PaginatedResponse.machine.ts
+++ b/src/app/machines/PaginatedResponse.machine.ts
@@ -320,7 +320,7 @@ export function makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
           entry: fetch,
           on: {
             'api.setResponse': {
-              actions: setResponse,
+              actions: [setResponse, model.actions.notifySuccess()],
             },
           },
           after: {

--- a/src/app/machines/PaginatedResponse.machine.ts
+++ b/src/app/machines/PaginatedResponse.machine.ts
@@ -102,7 +102,6 @@ export function makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
       },
     }
   );
-
   const setResponse = model.assign((context, e) => {
     if (e.page !== context.request.page) return {};
     if (context.onBeforeSetResponse) {
@@ -116,7 +115,6 @@ export function makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
       },
     };
   }, 'api.setResponse');
-
   const fetch = model.assign((context) => {
     if (context.actor && context.actor.stop) {
       context.actor.stop();
@@ -317,10 +315,11 @@ export function makePaginatedApiMachine<RawDataType, OrderBy, Search, DataType>(
           },
         },
         polling: {
-          entry: fetch,
+          entry: [model.actions.notifyLoading(), fetch],
           on: {
             'api.setResponse': {
               actions: [setResponse, model.actions.notifySuccess()],
+              cond: 'isPollingEnabled',
             },
           },
           after: {


### PR DESCRIPTION
It fixes the issue when unable to select a newly added Kafka Instance or Namespace when polling is enabled.