### PR TITLE
MGDCTRS 1488: Fix the secrets display on the debezium review page

### DIFF
--- a/src/app/pages/CreateConnectorPage/StepReview.tsx
+++ b/src/app/pages/CreateConnectorPage/StepReview.tsx
@@ -300,7 +300,7 @@ export const StepReviewComponent: React.FC<StepReviewComponentProps> = ({
             {connector === undefined &&
               Object.keys(modifiedObject).map((el) => {
                 return (
-                  <Grid key={el} style={{ color: 'red' }}>
+                  <Grid key={el}>
                     <GridItem span={4}>
                       <strong>{_.startCase(el)}</strong>
                     </GridItem>


### PR DESCRIPTION
Fix the secrets display on the debezium connector review page
 <img width="1396" alt="image" src="https://user-images.githubusercontent.com/8264372/205010168-aed52ce1-2157-410c-8d77-258d01825f62.png">
