### PR TITLE
MGDCTRS-1850 chore: add a link to the SA guide

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -30,6 +30,11 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: {
+      order: ['Pages', 'UI', 'Wizard Step 1', 'Wizard Step 3', 'Wizard Step 4.1', 'Wizard Step 4.2', 'Wizard Step 4.3', 'Wizard Step 5', 'ProofOfConcepts'],
+    },
+  }
 };
 
 export const decorators = [

--- a/cypress/e2e/connector-create.cy.ts
+++ b/cypress/e2e/connector-create.cy.ts
@@ -207,6 +207,7 @@ describe('Connector creation', () => {
         cy.findByLabelText('Connectors instance name *').type('my-connector');
         cy.findByLabelText('Client ID *').type('client-id');
         cy.findByLabelText('Client secret *').type('client-secret');
+        cy.findByLabelText('I have set the Kafka instance to allow access for this service account.*').click();
         cy.findByText('Next').should('be.enabled').click();
       },
 

--- a/locales/en/cos-ui.json
+++ b/locales/en/cos-ui.json
@@ -3,6 +3,7 @@
   "{{date}}": "{{date}}",
   "accepted": "Creation pending",
   "accessKey": "Access Key",
+  "accessPermissions": "Access permissions",
   "actions": "Actions",
   "addOnLink": "Learn more about add-on installation",
   "All Items": "All Items",
@@ -87,6 +88,7 @@
   "createKafkaInstance": "Create Kafka instance",
   "createPreviewNamespace": "Create a preview namespace",
   "createServiceAccount": "Create service account",
+  "createServiceAccountForKafkaGuideLink": "https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f351c4bd-9840-42ef-bcf2-b0c9be4ee30a#_7cb5e3f0-4b76-408d-b245-ff6959d3dbf7",
   "creationInProgress": "Creation in progress",
   "creationPending": "Creation pending",
   "createRosaNamespace": "Create a namespace on a ROSA cluster",
@@ -183,6 +185,7 @@
   "namespaceModelAlert": "The namespace will be ready shortly after creation.",
   "namespaceReady": "Namespace ready",
   "namespaceStepDescription": "The selected namespace hosts your Connectors instance. Use a namespace in an OpenShift Dedicated trial cluster, or have Red Hat create a preview namespace for you. For instructions on adding a namespace to a trial cluster, access the <2>guide</2>.",
+  "no": "No",
   "noConnectorInstances": "No Connectors instances",
   "noDeploymentNamespaceAvailable": "No deployment namespace available",
   "noFilterResultsFound": "No results match the filter criteria. <2>Clear all filters</2> to show results.",
@@ -219,6 +222,8 @@
   "serviceAccount": "Service account",
   "serviceAccountAlertMsg": "Make a copy of the client ID and secret to store in a safe place. The client secret won't appear again after closing this screen.",
   "serviceAccountDescText": "A service account enables the Connectors instance to authenticate with the Kafka instance. Provide credentials of a service account that has access to the Kafka instance, or create a new one. Define the service account's permissions from the Access tab of the Kafka instance so that source connectors can produce to, and sink connectors can consume from, topics.",
+  "serviceAccountInstructionsConfirmationDescription": "I configured the service account as described in <2>Setting permissions for a service account in a Kafka instance in OpenShift Streams for Apache Kafka.</2>",
+  "serviceAccountInstructionsConfirmationLabel": "I have set the Kafka instance to allow access for this service account.",
   "serviceAccountEditDescription": "A service account enables the Connectors instance to authenticate with a Kafka instance.",
   "shortDescription": "Short description",
   "shortDescriptionExampleText": "Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).",
@@ -255,5 +260,6 @@
   "viewJSONFormat": "View JSON format",
   "viewLess": "view less",
   "viewMore": "view more",
-  "clusteridSearchPlaceholder": "Filter by cluster id"
+  "clusteridSearchPlaceholder": "Filter by cluster id",
+  "yes": "Yes"
 }

--- a/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
+++ b/src/app/components/CreateConnectorWizard/CreateConnectorWizardContext.tsx
@@ -60,6 +60,8 @@ type CreateConnectorWizardProviderProps = {
   connectorData?: Connector;
   connectorTypeDetails?: ConnectorType;
   connectorId?: string;
+  selectedKafkaInstance?: KafkaRequest;
+  selectedNamespace?: ConnectorNamespace;
   duplicateMode?: boolean;
   onSave: (name: string) => void;
 };
@@ -76,6 +78,8 @@ export const CreateConnectorWizardProvider: FunctionComponent<
   connectorData,
   connectorTypeDetails,
   connectorId,
+  selectedKafkaInstance,
+  selectedNamespace,
   duplicateMode,
 }) => {
   const { onActivity } = useAnalytics();
@@ -98,6 +102,8 @@ export const CreateConnectorWizardProvider: FunctionComponent<
       connectorId,
       connectorData,
       connectorTypeDetails,
+      selectedKafkaInstance,
+      selectedNamespace,
       duplicateMode,
     },
     services: {
@@ -454,12 +460,19 @@ export const useNamespaceMachine = () => {
 export const useCoreConfigurationMachine = () => {
   const { coreConfigurationRef: coreConfigurationRef } =
     useCreateConnectorWizard();
-  const { name, sACreated, serviceAccount, duplicateMode } = useSelector(
+  const {
+    name,
+    sACreated,
+    sAConfiguredConfirmed,
+    serviceAccount,
+    duplicateMode,
+  } = useSelector(
     coreConfigurationRef,
     useCallback((state: EmittedFrom<typeof coreConfigurationRef>) => {
       return {
         name: state.context.name,
         sACreated: state.context.sACreated,
+        sAConfiguredConfirmed: state.context.sAConfiguredConfirmed,
         serviceAccount: state.context.userServiceAccount,
         duplicateMode: state.context.duplicateMode,
       };
@@ -479,6 +492,16 @@ export const useCoreConfigurationMachine = () => {
     [coreConfigurationRef]
   );
 
+  const onSetSaConfiguredConfirmed = useCallback(
+    (sAConfiguredConfirmed: boolean) => {
+      coreConfigurationRef.send({
+        type: 'setSaConfiguredConfirmed',
+        sAConfiguredConfirmed,
+      });
+    },
+    [coreConfigurationRef]
+  );
+
   const onSetServiceAccount = useCallback(
     (serviceAccount: UserProvidedServiceAccount) => {
       coreConfigurationRef.send({ type: 'setServiceAccount', serviceAccount });
@@ -489,7 +512,9 @@ export const useCoreConfigurationMachine = () => {
     serviceAccount,
     name,
     sACreated,
+    sAConfiguredConfirmed,
     onSetSaCreated,
+    onSetSaConfiguredConfirmed,
     onSetName,
     onSetServiceAccount,
     duplicateMode,

--- a/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.stories.tsx
+++ b/src/app/components/JsonSchemaConfigurator/JsonSchemaConfigurator.stories.tsx
@@ -28,7 +28,7 @@ import { StepBodyLayout } from '../StepBodyLayout/StepBodyLayout';
 import { JsonSchemaConfigurator } from './JsonSchemaConfigurator';
 
 export default {
-  title: 'Wizard step 4.2/Connector Form',
+  title: 'Wizard Step 4.2/Connector Form',
   component: JsonSchemaConfigurator,
   args: {
     configuration: {},

--- a/src/app/components/ViewJSONFormat/ViewJSONFormat.stories.tsx
+++ b/src/app/components/ViewJSONFormat/ViewJSONFormat.stories.tsx
@@ -74,7 +74,7 @@ const namespace_test = {
 };
 
 export default {
-  title: 'Wizard step 5/Json View',
+  title: 'Wizard Step 5/Json View',
   component: ViewJSONFormat,
   decorators: [(Story) => <Story />],
   args: {},

--- a/src/app/machines/CreateConnectorWizard.machine.ts
+++ b/src/app/machines/CreateConnectorWizard.machine.ts
@@ -47,6 +47,7 @@ export type CreateWizardContextData = {
   connectorConfiguration?: unknown;
   name: string;
   sACreated: boolean;
+  sAConfiguredConfirmed: boolean;
   topic?: string;
   userServiceAccount: UserProvidedServiceAccount;
   userErrorHandler?: string;
@@ -381,6 +382,8 @@ export const creationWizardMachine = model.createMachine(
               userErrorHandler: context.userErrorHandler,
               duplicateMode: context.duplicateMode,
               sACreated: context.sACreated,
+              sAConfiguredConfirmed:
+                context.duplicateMode || context.sAConfiguredConfirmed,
             };
           },
           onDone: {
@@ -388,6 +391,7 @@ export const creationWizardMachine = model.createMachine(
             actions: assign((context, event) => ({
               name: event.data.name,
               sACreated: event.data.sACreated,
+              sAConfiguredConfirmed: event.data.sAConfiguredConfirmed,
               userServiceAccount: event.data.userServiceAccount,
               duplicateMode: context.duplicateMode,
             })),

--- a/src/app/machines/StepCoreConfiguration.machine.ts
+++ b/src/app/machines/StepCoreConfiguration.machine.ts
@@ -7,6 +7,7 @@ import { createModel } from 'xstate/lib/model';
 type Context = {
   name: string;
   sACreated: boolean;
+  sAConfiguredConfirmed: boolean;
   userServiceAccount?: UserProvidedServiceAccount;
   duplicateMode?: boolean | undefined;
 };
@@ -15,12 +16,15 @@ const model = createModel(
   {
     name: '',
     sACreated: false,
+    sAConfiguredConfirmed: false,
     userServiceAccount: { clientId: '', clientSecret: '' },
   } as Context,
   {
     events: {
       setName: (payload: { name: string }) => payload,
       setSaCreated: (payload: { sACreated: boolean }) => payload,
+      setSaConfiguredConfirmed: (payload: { sAConfiguredConfirmed: boolean }) =>
+        payload,
       setServiceAccount: (payload: {
         serviceAccount: UserProvidedServiceAccount;
       }) => payload,
@@ -40,6 +44,13 @@ const setSaCreated = model.assign(
     sACreated: (_, event) => event.sACreated,
   },
   'setSaCreated'
+);
+
+const setSaConfiguredConfirmed = model.assign(
+  {
+    sAConfiguredConfirmed: (_, event) => event.sAConfiguredConfirmed,
+  },
+  'setSaConfiguredConfirmed'
 );
 
 const setServiceAccount = model.assign(
@@ -80,6 +91,10 @@ export const coreConfigurationMachine = model.createMachine(
             target: 'verify',
             actions: setSaCreated,
           },
+          setSaConfiguredConfirmed: {
+            target: 'verify',
+            actions: setSaConfiguredConfirmed,
+          },
           setServiceAccount: {
             target: 'verify',
             actions: setServiceAccount,
@@ -98,6 +113,10 @@ export const coreConfigurationMachine = model.createMachine(
             target: 'verify',
             actions: setSaCreated,
           },
+          setSaConfiguredConfirmed: {
+            target: 'verify',
+            actions: setSaConfiguredConfirmed,
+          },
           setServiceAccount: {
             target: 'verify',
             actions: setServiceAccount,
@@ -114,6 +133,8 @@ export const coreConfigurationMachine = model.createMachine(
         data: {
           name: (context: Context) => context.name,
           sACreated: (context: Context) => context.sACreated,
+          sAConfiguredConfirmed: (context: Context) =>
+            context.sAConfiguredConfirmed,
           userServiceAccount: (context: Context) => context.userServiceAccount,
           duplicateMode: (context: Context) => context.duplicateMode,
         },
@@ -123,13 +144,14 @@ export const coreConfigurationMachine = model.createMachine(
   {
     guards: {
       isCoreConfigurationConfigured: (context) => {
-        const { name, userServiceAccount } = context;
+        const { name, userServiceAccount, sAConfiguredConfirmed } = context;
         return (
           name !== undefined &&
           name.length > 0 &&
           userServiceAccount !== undefined &&
           userServiceAccount.clientId.length > 0 &&
-          userServiceAccount.clientSecret.length > 0
+          userServiceAccount.clientSecret.length > 0 &&
+          sAConfiguredConfirmed
         );
       },
     },

--- a/src/app/pages/CreateConnectorPage/StepCoreConfiguration.css
+++ b/src/app/pages/CreateConnectorPage/StepCoreConfiguration.css
@@ -1,3 +1,3 @@
 .step-common_service_account-desc {
-  font-size: var(--pf-global--FontSize--sm);
+  color: var(--pf-c-content--Color) !important;
 }

--- a/src/app/pages/CreateConnectorPage/StepCoreConfiguration.stories.tsx
+++ b/src/app/pages/CreateConnectorPage/StepCoreConfiguration.stories.tsx
@@ -1,0 +1,54 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import { CosContextProvider } from '../../../hooks/useCos';
+import { AlertsProvider } from '../../components/Alerts/Alerts';
+import { StepCoreConfigurationInner } from './StepCoreConfiguration';
+
+export default {
+  title: 'Wizard Step 4.1/Core Configuration Step',
+  component: StepCoreConfigurationInner,
+  decorators: [
+    (Story) => (
+      <AlertsProvider>
+        <CosContextProvider
+          getToken={() => Promise.resolve('')}
+          connectorsApiBasePath={'https://dummy.server'}
+          kafkaManagementApiBasePath={'https://dummy.server.kakfa'}
+        >
+          <Story />
+        </CosContextProvider>
+      </AlertsProvider>
+    ),
+  ],
+  args: {
+    duplicateMode: false,
+    name: 'Some Awesome Connector',
+    sACreated: true,
+    serviceAccount: {
+      clientId: 'this-is-the-client-id-right-here',
+      clientSecret: 'this-is-sooper-sekret-',
+    },
+  },
+} as ComponentMeta<typeof StepCoreConfigurationInner>;
+
+const Template: ComponentStory<typeof StepCoreConfigurationInner> = (args) => (
+  <StepCoreConfigurationInner {...args} />
+);
+
+export const FilledIn = Template.bind({});
+FilledIn.args = { duplicateMode: false } as ComponentMeta<
+  typeof StepCoreConfigurationInner
+>;
+
+export const FilledInDuplicateMode = Template.bind({});
+FilledInDuplicateMode.args = {
+  duplicateMode: true,
+  sAConfiguredConfirmed: true,
+} as ComponentMeta<typeof StepCoreConfigurationInner>;
+
+export const SANotCreated = Template.bind({});
+SANotCreated.args = {
+  sACreated: false,
+  serviceAccount: undefined,
+} as ComponentMeta<typeof StepCoreConfigurationInner>;

--- a/src/app/pages/CreateConnectorPage/StepCoreConfiguration.tsx
+++ b/src/app/pages/CreateConnectorPage/StepCoreConfiguration.tsx
@@ -1,3 +1,4 @@
+import { UserProvidedServiceAccount } from '@apis/api';
 import { useCoreConfigurationMachine } from '@app/components/CreateConnectorWizard/CreateConnectorWizardContext';
 import { CreateServiceAccount } from '@app/components/CreateServiceAccount/CreateServiceAccount';
 import { StepBodyLayout } from '@app/components/StepBodyLayout/StepBodyLayout';
@@ -7,26 +8,72 @@ import {
   Grid,
   Form,
   FormGroup,
+  Text,
   TextInput,
   TextContent,
   Button,
+  TextVariants,
+  ButtonVariant,
+  Checkbox,
 } from '@patternfly/react-core';
 
-import { useTranslation } from '@rhoas/app-services-ui-components';
+import { Trans, useTranslation } from '@rhoas/app-services-ui-components';
 
 import './StepCoreConfiguration.css';
 
 export const StepCoreConfiguration: FC = () => {
-  const { t } = useTranslation();
   const {
-    name = '',
-    serviceAccount = { clientId: '', clientSecret: '' },
-    sACreated = false,
+    name,
+    serviceAccount,
+    sACreated,
+    sAConfiguredConfirmed,
     onSetSaCreated,
+    onSetSaConfiguredConfirmed,
     onSetName,
     onSetServiceAccount,
     duplicateMode,
   } = useCoreConfigurationMachine();
+  return (
+    <StepCoreConfigurationInner
+      duplicateMode={duplicateMode!}
+      name={name}
+      serviceAccount={serviceAccount}
+      sACreated={sACreated}
+      sAConfiguredConfirmed={sAConfiguredConfirmed}
+      onSetName={onSetName}
+      onSetSaCreated={onSetSaCreated}
+      onSetSaConfiguredConfirmed={onSetSaConfiguredConfirmed}
+      onSetServiceAccount={onSetServiceAccount}
+    />
+  );
+};
+
+export type StepCoreConfigurationInnerProps = {
+  duplicateMode: boolean;
+  name: string;
+  serviceAccount?: UserProvidedServiceAccount;
+  sACreated?: boolean;
+  sAConfiguredConfirmed?: boolean;
+  onSetName: (name: string) => void;
+  onSetSaCreated: (sACreated: boolean) => void;
+  onSetSaConfiguredConfirmed: (sAConfiguredConfirmed: boolean) => void;
+  onSetServiceAccount: (serviceAccount: UserProvidedServiceAccount) => void;
+};
+
+export const StepCoreConfigurationInner: FC<
+  StepCoreConfigurationInnerProps
+> = ({
+  duplicateMode,
+  name = '',
+  serviceAccount = { clientId: '', clientSecret: '' },
+  sACreated = false,
+  sAConfiguredConfirmed = false,
+  onSetName,
+  onSetSaCreated,
+  onSetSaConfiguredConfirmed,
+  onSetServiceAccount,
+}) => {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleModalToggle = () => {
     setIsOpen(!isOpen);
@@ -51,9 +98,12 @@ export const StepCoreConfiguration: FC = () => {
               className="pf-u-mb-0"
             >
               <TextContent>
-                <span className="step-common_service_account-desc">
+                <Text
+                  component={TextVariants.small}
+                  className={'step-common_service_account-desc'}
+                >
                   {t('serviceAccountDescText')}
-                </span>
+                </Text>
               </TextContent>
               <Button
                 variant="secondary"
@@ -66,42 +116,81 @@ export const StepCoreConfiguration: FC = () => {
               </Button>
             </FormGroup>
 
-            {serviceAccount && (
-              <>
-                <FormGroup
-                  label={t('clientId')}
-                  isRequired
-                  fieldId="clientId"
-                  className="pf-u-mb-0"
-                >
-                  <TextInput
-                    value={serviceAccount.clientId}
-                    onChange={(clientId) =>
-                      onSetServiceAccount({ ...serviceAccount, clientId })
+            <FormGroup
+              label={t('clientId')}
+              isRequired
+              fieldId="clientId"
+              className="pf-u-mb-0"
+            >
+              <TextInput
+                value={serviceAccount.clientId}
+                onChange={(clientId) =>
+                  onSetServiceAccount({ ...serviceAccount, clientId })
+                }
+                id="clientId"
+              />
+            </FormGroup>
+            <FormGroup
+              label={t('clientSecret')}
+              isRequired
+              fieldId="clientSecret"
+              className="pf-u-mb-0"
+              helperText={
+                duplicateMode ? t('credentialDuplicateFieldHelpText') : ''
+              }
+            >
+              <TextInput
+                value={serviceAccount.clientSecret}
+                type={'password'}
+                onChange={(clientSecret) =>
+                  onSetServiceAccount({ ...serviceAccount, clientSecret })
+                }
+                id="clientSecret"
+              />
+            </FormGroup>
+            <FormGroup fieldId="saConfiguredConfirmation">
+              <Checkbox
+                label={
+                  <Trans
+                    i18nKey={'serviceAccountInstructionsConfirmationLabel'}
+                  >
+                    I have set the Kafka instance to allow access for this
+                    service account.
+                  </Trans>
+                }
+                description={
+                  <Trans
+                    i18nKey={
+                      'serviceAccountInstructionsConfirmationDescription'
                     }
-                    id="clientId"
-                  />
-                </FormGroup>
-                <FormGroup
-                  label={t('clientSecret')}
-                  isRequired
-                  fieldId="clientSecret"
-                  className="pf-u-mb-0"
-                  helperText={
-                    duplicateMode ? t('credentialDuplicateFieldHelpText') : ''
-                  }
-                >
-                  <TextInput
-                    value={serviceAccount.clientSecret}
-                    type={'password'}
-                    onChange={(clientSecret) =>
-                      onSetServiceAccount({ ...serviceAccount, clientSecret })
-                    }
-                    id="clientSecret"
-                  />
-                </FormGroup>
-              </>
-            )}
+                  >
+                    I configured the service account as described in{' '}
+                    <Button
+                      variant={ButtonVariant.link}
+                      isSmall
+                      isInline
+                      component={'a'}
+                      href={t('createServiceAccountForKafkaGuideLink')}
+                      target={'_blank'}
+                      ouiaId={'description-service-account-guide-link'}
+                    >
+                      Setting permissions for a service account in a Kafka
+                      instance in OpenShift Streams for Apache Kafka.
+                    </Button>
+                  </Trans>
+                }
+                id="saConfiguredConfirmation"
+                name="saConfiguredConfirmation"
+                ouiaId={'sa-configured-confirmation-checkbox'}
+                data-testid={'sa-configured-confirmation-checkbox'}
+                aria-label="service account configured confirmation"
+                isRequired={true}
+                isChecked={sAConfiguredConfirmed}
+                onChange={() =>
+                  onSetSaConfiguredConfirmed(!sAConfiguredConfirmed)
+                }
+              />
+            </FormGroup>
           </Form>
         </Grid>
       </StepBodyLayout>

--- a/src/app/pages/CreateConnectorPage/StepReview.stories.tsx
+++ b/src/app/pages/CreateConnectorPage/StepReview.stories.tsx
@@ -76,7 +76,7 @@ const namespace_test = {
 };
 
 export default {
-  title: 'Wizard step 5/Review Step',
+  title: 'Wizard Step 5/Review Step',
   component: StepReviewComponent,
   decorators: [(Story) => <Story />],
   args: {},


### PR DESCRIPTION
This commit adds some text and a link to the core configuration step to the user guide that covers service account creation and configuration for Kafka.  This change also adds reworks the core configuration step and adds some stories to storybook so it's easier to develop this step outside of the application.

Here's the storybook additions:
![Screenshot from 2023-01-16 14-24-59](https://user-images.githubusercontent.com/351660/212753064-a7ab8327-2404-4bbe-93f5-f1a6101b987e.png)

And when the user checks the checkbox:

![Screenshot from 2023-01-16 14-26-41](https://user-images.githubusercontent.com/351660/212753144-c5902a84-eaa6-4d05-a26f-b0497e33ae8e.png)

Finally the review step change:
![Screenshot from 2023-01-16 15-00-38](https://user-images.githubusercontent.com/351660/212757590-298de209-3d91-4ef0-92c4-55c06f5ef6c7.png)
