### PR TITLE
MGDCTRS-1773 fix: remove code formatting

### DIFF
--- a/src/app/components/SomethingWentWrongInline/SomethingWentWrongInline.tsx
+++ b/src/app/components/SomethingWentWrongInline/SomethingWentWrongInline.tsx
@@ -59,7 +59,6 @@ export const SomethingWentWrongInline: FC<SomethingWentWrongInlineProps> = ({
                 hoverTip={t('somethingWentWrongInlineHoverTip')}
                 clickTip={t('somethingWentWrongInlineClickTip')}
                 variant="inline-compact"
-                isCode
               >
                 {t('somethingWentWrongInlineEmail')}
               </ClipboardCopy>

--- a/src/app/components/SomethingWentWrongInline/SomethingWentWrongInlineNoSubscription.tsx
+++ b/src/app/components/SomethingWentWrongInline/SomethingWentWrongInlineNoSubscription.tsx
@@ -36,7 +36,6 @@ export const SomethingWentWrongInlineNoSubscription: FC<
                 hoverTip={t('somethingWentWrongInlineHoverTip')}
                 clickTip={t('somethingWentWrongInlineClickTip')}
                 variant="inline-compact"
-                isCode
               >
                 {t('somethingWentWrongInlineEmail')}
               </ClipboardCopy>


### PR DESCRIPTION
This change removes the monospace font from the email address used in the error handler alert message.