### PR TITLE
MGDCTRS-1875 fix: update missing copy text

### DIFF
--- a/locales/en/cos-ui.json
+++ b/locales/en/cos-ui.json
@@ -256,6 +256,8 @@
   "stopInstance": "Stop instance",
   "supportEmailMsg": " You can still get help by emailing us at <1> rhosak-eval-support@redhat.com </1>. This mailing list is monitored by the Red Hat OpenShift Application Services team.",
   "Tier": "Tier",
+  "tierPopoverHelpDescription": "Your subscription determines which tiers are available for production. Tiers not available in your subscription can also be created as a trial. <2>Contact us</2> to learn about the subscription options available for using this service in production.",
+  "tierPopoverHelpDescriptionLink": "https://www.redhat.com/en/technologies/cloud-computing/openshift/connectors",
   "timeCreated": "Time Created",
   "timeUpdated": "Time Updated",
   "topic": "Topic",

--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListFilterPanel.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListFilterPanel.tsx
@@ -9,6 +9,8 @@ import {
   VerticalTabsTab,
 } from '@patternfly/react-catalog-view-extension';
 import {
+  Button,
+  ButtonVariant,
   Popover,
   Text,
   TextContent,
@@ -16,7 +18,11 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import { Loading, useTranslation } from '@rhoas/app-services-ui-components';
+import {
+  Loading,
+  Trans,
+  useTranslation,
+} from '@rhoas/app-services-ui-components';
 
 import './ConnectorSelectionListFilterPanel.css';
 import { ConnectorTypeLabelCount } from './typeExtensions';
@@ -145,9 +151,24 @@ export const ConnectorSelectionListFilterPanel: FC<
                     position="right"
                     bodyContent={
                       <TextContent>
-                        <Text component={TextVariants.h5}>{t('TODO')}</Text>
-                        <Text component={TextVariants.h6}>{t('TODO')}</Text>
-                        <Text component={TextVariants.p}>{t('TODO')}</Text>
+                        <Text component={TextVariants.p}>
+                          <Trans i18nKey={'tierPopoverHelpDescription'}>
+                            Your subscription determines which tiers are
+                            available for production. Tiers not available in
+                            your subscription can also be created as a trial.{' '}
+                            <Button
+                              component={'a'}
+                              variant={ButtonVariant.link}
+                              isSmall
+                              isInline
+                              href={t('tierPopoverHelpDescriptionLink')}
+                            >
+                              Contact us
+                            </Button>{' '}
+                            to learn about the subscription options available
+                            for using this service in production.
+                          </Trans>
+                        </Text>
                       </TextContent>
                     }
                   >


### PR DESCRIPTION
This change adds some missing text into the subscription tier popover, replacing some TODOs.

![Screenshot from 2023-01-24 10-59-17](https://user-images.githubusercontent.com/351660/214344396-d9429be3-b5ad-4b0a-ab86-f0cf2d972354.png)
