### PR TITLE
MGDCTRS-1912 fix: remove sort control

### DIFF
--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListItem.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListItem.tsx
@@ -50,23 +50,13 @@ export const ConnectorSelectionListItem: FC<
   const displayLabels = labels
     .filter(
       (label) =>
-        label !== 'source' && label !== 'sink' && label.startsWith('category-')
+        label !== 'source' &&
+        label !== 'sink' &&
+        label !== 'category-featured' &&
+        label.startsWith('category-')
     )
-    .sort((a, b) =>
-      a === 'category-featured'
-        ? 1
-        : a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase())
-    )
-    .map((label) =>
-      label === 'category-featured' ? (
-        <Label key={label}>
-          <OutlinedStarIcon />
-          &nbsp;{t(label)}
-        </Label>
-      ) : (
-        <Label key={label}>{t(label)}</Label>
-      )
-    );
+    .sort((a, b) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase()))
+    .map((label) => <Label key={label}>{t(label)}</Label>);
   return (
     <DataListItem aria-labelledby={id} id={id} style={{ ...style }}>
       <DataListItemRow>
@@ -110,10 +100,20 @@ export const ConnectorSelectionListItem: FC<
                 <FlexItem>
                   <LabelGroup numLabels={labels.length + 1}>
                     {labels.includes('source') ? (
-                      <Label color="blue">Source</Label>
+                      <Label key="source" color="blue">
+                        Source
+                      </Label>
                     ) : (
-                      <Label color="green">Sink</Label>
+                      <Label key="sink" color="green">
+                        Sink
+                      </Label>
                     )}
+                    {labels.includes('category-featured') ? (
+                      <Label key={'category-featured'}>
+                        <OutlinedStarIcon />
+                        &nbsp;{t('category-featured')}
+                      </Label>
+                    ) : undefined}
                     {displayLabels}
                   </LabelGroup>
                 </FlexItem>

--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListToolbar.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListToolbar.tsx
@@ -9,14 +9,10 @@ import {
   ToolbarToggleGroup,
   TextContent,
   TextVariants,
-  SelectVariant,
   ToolbarGroup,
-  Select,
-  SelectOption,
-  SelectOptionObject,
   SearchInput,
 } from '@patternfly/react-core';
-import { ArrowsAltVIcon } from '@patternfly/react-icons';
+import { FilterIcon } from '@patternfly/react-icons';
 
 import { useTranslation } from '@rhoas/app-services-ui-components';
 
@@ -37,22 +33,15 @@ export type ConnectorSelectionListToolbarProps = {
 export const ConnectorSelectionListToolbar: FC<
   ConnectorSelectionListToolbarProps
 > = ({
-  currentSort,
   currentCategory,
-  sortInputEntries,
   loading,
   total,
   searchFieldPlaceholder,
   searchFieldValue,
   onChangeSearchField,
-  onChangeSort,
 }) => {
   const { t } = useTranslation();
   const [currentSearch, setCurrentSearch] = useState(searchFieldValue);
-  const [isSortOpen, setIsSortOpen] = useState(false);
-  const primarySort = [
-    Object.keys(currentSort || {})[0] || sortInputEntries[0].value,
-  ];
   const toggleGroupItems = (
     <>
       <ToolbarGroup variant={'button-group'}>
@@ -84,37 +73,11 @@ export const ConnectorSelectionListToolbar: FC<
           />
         </ToolbarItem>
       </ToolbarGroup>
-      <ToolbarGroup variant={'filter-group'}>
-        <ToolbarItem>
-          <Select
-            isOpen={isSortOpen}
-            variant={SelectVariant.single}
-            aria-label={'sorting control'}
-            onToggle={setIsSortOpen}
-            onSelect={(_event, selection: SelectOptionObject | string) => {
-              if (typeof selection === 'string') {
-                onChangeSort(selection);
-              } else {
-                onChangeSort((selection as SelectOptionObject).toString());
-              }
-              setIsSortOpen(false);
-            }}
-            selections={primarySort}
-            isDisabled={loading}
-          >
-            {sortInputEntries.map(({ value, label }, index) => (
-              <SelectOption key={index} value={value}>
-                {t(label)}
-              </SelectOption>
-            ))}
-          </Select>
-        </ToolbarItem>
-      </ToolbarGroup>
     </>
   );
   const toolbarItems = (
     <>
-      <ToolbarToggleGroup toggleIcon={<ArrowsAltVIcon />} breakpoint="xl">
+      <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
         {toggleGroupItems}
       </ToolbarToggleGroup>
       {!loading && (


### PR DESCRIPTION
This change removes the sort control from the connector type selector toolbar to save some screen real estate.  This commit also updates icon used when the filter control collapses in narrower viewports.  Finally, this change also includes a small tweak to the order in the labels for featured items to be consistent.