### PR TITLE
MGDCTRS-1922 fix: decouple cache storage

### DIFF
--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionList.stories.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionList.stories.tsx
@@ -10,6 +10,7 @@ import {
   ConnectorSelectionList,
   ConnectorSelectionListInnerProps,
 } from './ConnectorSelectionList';
+import { ConnectorSelectionListCacheStorageProvider } from './ConnectorSelectionListCacheStorage';
 import { FeaturedConnectorType } from './typeExtensions';
 
 const API_HOST = 'https://dummy.server';
@@ -39,7 +40,9 @@ export default {
             connectorsApiBasePath={API_HOST}
             kafkaManagementApiBasePath={API_HOST}
           >
-            <Story />
+            <ConnectorSelectionListCacheStorageProvider>
+              <Story />
+            </ConnectorSelectionListCacheStorageProvider>
           </CosContextProvider>
         </StepBodyLayout>
       </>

--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionList.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionList.tsx
@@ -19,6 +19,7 @@ import {
   ObjectReference,
 } from '@rhoas/connector-management-sdk';
 
+import { useConnectorSelectionListCacheStorage } from './ConnectorSelectionListCacheStorage';
 import { ConnectorSelectionListLayout } from './ConnectorSelectionListLayout';
 import {
   ConnectorTypeLabelCount,
@@ -46,6 +47,7 @@ export const ConnectorSelectionList: FC<ConnectorSelectionListProps> = ({
   renderSelector,
 }) => {
   const { connectorsApiBasePath, getToken } = useCos();
+  const { clear: clearCache } = useConnectorSelectionListCacheStorage();
   const [initialSet, setInitialSet] = useState<
     Array<FeaturedConnectorType> | undefined
   >(undefined);
@@ -174,40 +176,44 @@ export const ConnectorSelectionList: FC<ConnectorSelectionListProps> = ({
     (name: string) => {
       setPagination({ page: 1, total: 0 });
       setInitialSet(undefined);
+      clearCache();
       setSearch({ ...search, name });
     },
-    [setSearch, search, setInitialSet]
+    [clearCache, setSearch, search, setInitialSet]
   );
 
   const doSetPricingTierSearch = useCallback(
     (pricingTier: string) => {
       setPagination({ page: 1, total: 0 });
       setInitialSet(undefined);
+      clearCache();
       // this set timeout ensures the pricing tier filter checkboxes feel responsive to the user
       setTimeout(() => setSearch({ ...search, pricing_tier: pricingTier }), 0);
     },
-    [setSearch, search, setInitialSet]
+    [clearCache, setSearch, search, setInitialSet]
   );
 
   const doSetLabelSearch = useCallback(
     (label: Array<string>) => {
       setPagination({ page: 1, total: 0 });
       setInitialSet(undefined);
+      clearCache();
       // this set timeout ensures the source/sink checkboxes feel responsive to the user
       setTimeout(() => setSearch({ ...search, label }), 0);
     },
-    [setSearch, search, setInitialSet]
+    [clearCache, setSearch, search, setInitialSet]
   );
 
   const doResetAllFilters = useCallback(() => {
     setPagination({ page: 1, total: 0 });
     setInitialSet(undefined);
+    clearCache();
     setSearch({
       name: '',
       label: [],
       pricing_tier: '',
     });
-  }, [setSearch, setInitialSet]);
+  }, [clearCache, setSearch, setInitialSet]);
 
   const sortInputEntries = [
     {

--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListCacheStorage.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListCacheStorage.tsx
@@ -1,0 +1,97 @@
+import React, { createContext, FC, useContext } from 'react';
+
+import { FeaturedConnectorType } from './typeExtensions';
+
+export type ConnectorSelectionListCacheStorageContextType = {
+  clear: () => void;
+  find: (
+    condition: (item: FeaturedConnectorType | boolean) => boolean
+  ) => FeaturedConnectorType | boolean;
+  get: (index: number) => FeaturedConnectorType | boolean;
+  init: (
+    initialSet: Array<FeaturedConnectorType | boolean>,
+    total: number
+  ) => void;
+  put: (
+    index: number,
+    item: FeaturedConnectorType | boolean
+  ) => FeaturedConnectorType | boolean;
+};
+
+const ConnectorSelectionListCacheStorageContext =
+  createContext<ConnectorSelectionListCacheStorageContextType>({
+    clear: () => {},
+    get: (_) => false,
+    init: (_) => {},
+    find: (_) => false,
+    put: (_) => false,
+  });
+
+export const ConnectorSelectionListCacheStorageProvider: FC<{}> = ({
+  children,
+}) => {
+  let cachedTotal = 0;
+  let cache: { [key: number]: FeaturedConnectorType | boolean } = {};
+
+  const init = (
+    initialSet: Array<FeaturedConnectorType | boolean>,
+    total: number
+  ) => {
+    if (total === cachedTotal) {
+      return;
+    }
+    const loadedConnectorTypesMap: {
+      [key: number]: FeaturedConnectorType | boolean;
+    } = Array.from({ length: total - 1 })
+      .map((_, index) => ({ [index]: false }))
+      .reduce((prev, current) => ({ ...prev, ...current }), {});
+    if (typeof initialSet !== 'undefined' && initialSet !== null) {
+      initialSet.forEach(
+        (item, index) => (loadedConnectorTypesMap[index] = item)
+      );
+    }
+    cachedTotal = total;
+    cache = loadedConnectorTypesMap;
+  };
+
+  const get = (index: number) => cache[index];
+  const put = (index: number, item: FeaturedConnectorType | boolean) => {
+    const old = cache[index];
+    cache[index] = item;
+    return old;
+  };
+  const find = (
+    condition: (item: FeaturedConnectorType | boolean) => boolean
+  ) => {
+    return Object.values(cache).find(condition) || false;
+  };
+  const clear = () => {
+    cachedTotal = 0;
+    cache = {};
+  };
+
+  return (
+    <ConnectorSelectionListCacheStorageContext.Provider
+      value={{
+        clear,
+        get,
+        init,
+        find,
+        put,
+      }}
+    >
+      {children}
+    </ConnectorSelectionListCacheStorageContext.Provider>
+  );
+};
+
+export const useConnectorSelectionListCacheStorage =
+  (): ConnectorSelectionListCacheStorageContextType => {
+    const service = useContext(ConnectorSelectionListCacheStorageContext);
+    if (!service) {
+      throw new Error(
+        `useConnectorSelectionListCacheStorage() must be used in a child of <ConnectorSelectionListCacheStorageContextProvider>`
+      );
+    }
+    return service;
+  };

--- a/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
+++ b/src/app/pages/CreateConnectorPage/CreateConnectorPage.tsx
@@ -1,3 +1,4 @@
+import { ConnectorSelectionListCacheStorageProvider } from '@app/components/ConnectorSelectionList/ConnectorSelectionListCacheStorage';
 import { CreateConnectorWizard } from '@app/components/CreateConnectorWizard/CreateConnectorWizard';
 import { CreateConnectorWizardProvider } from '@app/components/CreateConnectorWizard/CreateConnectorWizardContext';
 import { useCos } from '@hooks/useCos';
@@ -59,26 +60,28 @@ export const CreateConnectorPage: FunctionComponent<
           type={'default'}
           variant={'light'}
         >
-          <CreateConnectorWizard
-            header={<ConnectorWizardHeader />}
-            onClose={openLeaveConfirm}
-          />
-          <Modal
-            title={t('leaveCreateConnectorConfirmModalTitle')}
-            variant={'small'}
-            isOpen={askForLeaveConfirm}
-            onClose={closeLeaveConfirm}
-            actions={[
-              <Button key="confirm" variant="primary" onClick={onClose}>
-                Confirm
-              </Button>,
-              <Button key="cancel" variant="link" onClick={closeLeaveConfirm}>
-                Cancel
-              </Button>,
-            ]}
-          >
-            {t('leaveCreateConnectorConfirmModalDescription')}
-          </Modal>
+          <ConnectorSelectionListCacheStorageProvider>
+            <CreateConnectorWizard
+              header={<ConnectorWizardHeader />}
+              onClose={openLeaveConfirm}
+            />
+            <Modal
+              title={t('leaveCreateConnectorConfirmModalTitle')}
+              variant={'small'}
+              isOpen={askForLeaveConfirm}
+              onClose={closeLeaveConfirm}
+              actions={[
+                <Button key="confirm" variant="primary" onClick={onClose}>
+                  {t('Confirm')}
+                </Button>,
+                <Button key="cancel" variant="link" onClick={closeLeaveConfirm}>
+                  {t('Cancel')}
+                </Button>,
+              ]}
+            >
+              {t('leaveCreateConnectorConfirmModalDescription')}
+            </Modal>
+          </ConnectorSelectionListCacheStorageProvider>
         </PageSection>
       </CreateConnectorWizardProvider>
     </>


### PR DESCRIPTION
This change separates the cache used to store connector types by the connector selection list into two separate components, one component to act as a simple storage to cache API responses, and a second component that takes care of managing that cache based on application state, so that the storage of API responses can be lifted to a point where it won't be discarded due to a rerender, which occurs when the user selects an item from the list.

Now you can scroll, click on a list item and then still scroll and nothing weird happens like it was behaving before :smile: 