### PR TITLE
MGDCTRS-1456 fix: handle enter key in delete modal

### DIFF
--- a/src/app/components/DialogDeleteConnector/DialogDeleteConnector.tsx
+++ b/src/app/components/DialogDeleteConnector/DialogDeleteConnector.tsx
@@ -81,6 +81,12 @@ export const DialogDeleteConnector: React.FunctionComponent<
             value={nameValue}
             type="text"
             onChange={setNameValue}
+            onKeyUp={(e) => {
+              if (e.key === 'Enter' && canDelete) {
+                onConfirmDelete();
+                e.preventDefault();
+              }
+            }}
             aria-label="name input"
             data-testid={'delete-connector-instance-modal-input'}
           />


### PR DESCRIPTION
This commit enables the user to type the connector name and press enter to confirm deleting a connector provided the connector name matches.