### PR TITLE
MGDCTRS-2139 chore: hide pricing tier elements

### DIFF
--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListFilterPanel.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListFilterPanel.tsx
@@ -9,23 +9,14 @@ import {
   VerticalTabsTab,
 } from '@patternfly/react-catalog-view-extension';
 import {
-  Button,
-  ButtonVariant,
   Popover,
   Text,
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import {
-  ExternalLinkAltIcon,
-  OutlinedQuestionCircleIcon,
-} from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import {
-  Loading,
-  Trans,
-  useTranslation,
-} from '@rhoas/app-services-ui-components';
+import { Loading, useTranslation } from '@rhoas/app-services-ui-components';
 
 import './ConnectorSelectionListFilterPanel.css';
 import { ConnectorTypeLabelCount } from './typeExtensions';
@@ -51,8 +42,6 @@ export const ConnectorSelectionListFilterPanel: FC<
   labels,
   selectedCategories = [],
   onChangeLabelFilter,
-  selectedPricingTier,
-  onChangePricingTierFilter,
   onAdjustViewportHeight,
 }) => {
   const { t } = useTranslation();
@@ -145,6 +134,7 @@ export const ConnectorSelectionListFilterPanel: FC<
                 {t('Sink')}
               </FilterSidePanelCategoryItem>
             </FilterSidePanelCategory>
+            {/*
             <FilterSidePanelCategory
               key={'subscription-tier'}
               title={
@@ -196,6 +186,7 @@ export const ConnectorSelectionListFilterPanel: FC<
                 </FilterSidePanelCategoryItem>
               ))}
             </FilterSidePanelCategory>
+            */}
           </>
         )}
         <FilterSidePanelCategory key={'category-nav'}>

--- a/src/app/components/ConnectorSelectionList/ConnectorSelectionListItem.tsx
+++ b/src/app/components/ConnectorSelectionList/ConnectorSelectionListItem.tsx
@@ -44,7 +44,7 @@ export type ConnectorSelectionListItemProps = {
 
 export const ConnectorSelectionListItem: FC<
   ConnectorSelectionListItemProps
-> = ({ id, labels = [], title, version, description, pricingTier, style }) => {
+> = ({ id, labels = [], title, version, description, style }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const displayLabels = labels
@@ -140,11 +140,14 @@ export const ConnectorSelectionListItem: FC<
                 </DescriptionListGroup>
               </DescriptionList>
             </StackItem>
+            {/*
+            
             <StackItem key={'tier'}>
               <LabelGroup>
                 {pricingTier !== '' && <Label>{t(pricingTier)}</Label>}
               </LabelGroup>
             </StackItem>
+          */}
           </Stack>
         </DataListAction>
       </DataListItemRow>


### PR DESCRIPTION
This change temporarily hides the filter and pricing tier badge from the UI until it's needed.

![Screenshot from 2023-03-17 13-40-25](https://user-images.githubusercontent.com/351660/225979313-6b834deb-0e69-4090-b469-7e58772f0689.png)
