### PR TITLE
MGDCTRS-2235 chore: update ignore description

### DIFF
--- a/locales/en/cos-ui.json
+++ b/locales/en/cos-ui.json
@@ -149,7 +149,7 @@
   "hideSecretFields": "Hide secret fields",
   "id": "id",
   "ignore": "Ignore",
-  "ignoreDescription": "If a message fails to send, the Connectors instance ignores the error and continues to run. To see the reason for the failure, view the Connectors instance details.",
+  "ignoreDescription": "If a message fails to send, the Connectors instance ignores the error and continues to run.",
   "input_field_invalid_message": "Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).",
   "items_one": "{{count}} Item",
   "items_other": "{{count}} Items",


### PR DESCRIPTION
This change removes an incorrect statement in the description text for the ignore error handler method.

![Screenshot from 2023-04-10 12-52-10](https://user-images.githubusercontent.com/351660/230950991-71795cac-9e00-4bd0-84e6-b30956e468ad.png)
