### PR TITLE
MGDCTRS-2303 chore: disable connector creation

### DIFF
--- a/cypress/e2e/connector-create.cy.ts
+++ b/cypress/e2e/connector-create.cy.ts
@@ -153,7 +153,7 @@ function runTheTests(testModel: TestModel<any, any>) {
     describe(plan.description, () => {
       // beforeEach(async mockApis.makeHappyPath);
       plan.paths.forEach((path) => {
-        it(path.description, () => {
+        xit(path.description, () => {
           // const onClose = jest.fn();
           // const onSave = jest.fn();
 

--- a/cypress/e2e/connector-overview.cy.ts
+++ b/cypress/e2e/connector-overview.cy.ts
@@ -40,7 +40,7 @@ describe(
       cy.wait('@slack-connector-kafka-namespace');
     };
 
-    it('should show the overview for a connector with the appropriate kafka and namespace', () => {
+    xit('should show the overview for a connector with the appropriate kafka and namespace', () => {
       cy.visit(Cypress.env('overview'));
       waitForData();
       cy.findByText('cc1p3tjvcap6794aj210').should('exist');
@@ -48,7 +48,7 @@ describe(
       cy.findByText('default-connector-namespace').should('exist');
     });
 
-    it('should show the connector configuration, edit the properties, clear a value and save it successfully', () => {
+    xit('should show the connector configuration, edit the properties, clear a value and save it successfully', () => {
       cy.visit(Cypress.env('overview'));
       waitForData();
       cy.findByText('Configuration').click();
@@ -70,7 +70,7 @@ describe(
         });
     });
 
-    it('should change the error handler from stop to log with the correct request', () => {
+    xit('should change the error handler from stop to log with the correct request', () => {
       cy.visit(Cypress.env('overview'));
       waitForData();
       cy.findByText('Configuration').click();

--- a/cypress/e2e/connectors-instances.cy.ts
+++ b/cypress/e2e/connectors-instances.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 describe('Connectors page', () => {
-  it('should render a list of connectors as expected and poll for updates, the call to action to create a connector works', () => {
+  xit('should render a list of connectors as expected and poll for updates, the call to action to create a connector works', () => {
     cy.clock();
     // first load, we should see a single connector
     cy.intercept(Cypress.env('connectorsApiPath'), {
@@ -142,7 +142,7 @@ describe('Connectors page', () => {
     cy.wait('@deletePatch').its('request.body').should('deep.equal', '');
   });
 
-  it('shows an empty state with no connectors, the call to action to create a connector works', () => {
+  xit('shows an empty state with no connectors, the call to action to create a connector works', () => {
     cy.intercept(Cypress.env('connectorsApiPath'), {
       fixture: 'noConnectors.json',
     }).as('noConnectors');

--- a/src/CosRoutes.tsx
+++ b/src/CosRoutes.tsx
@@ -1,12 +1,7 @@
 import { ConnectorDetailsPage } from '@app/pages/ConnectorDetailsPage/ConnectorDetailsPage';
 import { ConnectorsPage } from '@app/pages/ConnectorsPage/ConnectorsPage';
-import { CreateConnectorPage } from '@app/pages/CreateConnectorPage/CreateConnectorPage';
-import { DuplicateConnectorPage } from '@app/pages/CreateConnectorPage/DuplicateConnectorPage';
 import React, { FunctionComponent, useCallback } from 'react';
-import { Route, Switch, useHistory } from 'react-router-dom';
-
-import { useTranslation } from '@rhoas/app-services-ui-components';
-import { AlertVariant, useAlert } from '@rhoas/app-services-ui-shared';
+import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 
 import { CosContextProvider } from './hooks/useCos';
 
@@ -21,8 +16,10 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
   connectorsApiBasePath,
   kafkaManagementApiBasePath,
 }) => {
+  /*
   const { t } = useTranslation();
   const alert = useAlert();
+  */
   const history = useHistory();
   const goToConnectorsList = useCallback(() => history.push('/'), [history]);
   const goToCreateConnector = useCallback(
@@ -46,6 +43,7 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
     [history]
   );
 
+  /*
   const onConnectorSave = useCallback(
     (name: string) => {
       alert?.addAlert({
@@ -58,6 +56,7 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
     },
     [alert, goToConnectorsList, t]
   );
+  */
   return (
     <CosContextProvider
       getToken={getToken}
@@ -73,16 +72,22 @@ export const CosRoutes: FunctionComponent<CosRoutesProps> = ({
           />
         </Route>
         <Route path={'/create-connector'}>
+          <Redirect to={'/'} />
+          {/*
           <CreateConnectorPage
             onSave={onConnectorSave}
             onClose={goToConnectorsList}
           />
+          */}
         </Route>
         <Route path={'/duplicate-connector'}>
+          <Redirect to={'/'} />
+          {/*
           <DuplicateConnectorPage
             onSave={onConnectorSave}
             onClose={goToConnectorsList}
           />
+          */}
         </Route>
         <Route path={'/:id/'}>
           <ConnectorDetailsPage

--- a/src/app/components/EmptyStateGettingStarted/EmptyStateGettingStarted.tsx
+++ b/src/app/components/EmptyStateGettingStarted/EmptyStateGettingStarted.tsx
@@ -78,7 +78,12 @@ export const EmptyStateGettingStarted: FunctionComponent<
           </Trans>
         </Text>
       </EmptyStateBody>
-      <Button variant={'primary'} onClick={onCreate} ouiaId={'button-create'}>
+      <Button
+        isDisabled
+        variant={'primary'}
+        onClick={onCreate}
+        ouiaId={'button-create'}
+      >
         {t('createConnectorsInstance')}
       </Button>
     </EmptyState>

--- a/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.tsx
+++ b/src/app/pages/ConnectorsPage/components/ConnectorInstancesTable/ConnectorInstancesTable.tsx
@@ -4,7 +4,6 @@ import { EmptyStateNoMatchesFound } from '@app/components/EmptyStateNoMatchesFou
 import { ConnectorMachineActorRef } from '@app/machines/Connector.machine';
 import { validateSearchField } from '@utils/shared';
 import React, { FunctionComponent } from 'react';
-import { NavLink } from 'react-router-dom';
 
 import { Card, PageSection } from '@patternfly/react-core';
 
@@ -142,7 +141,8 @@ export const ConnectorInstancesTable: FunctionComponent<
               errorMessage: t('input_field_invalid_message'),
             },
           }}
-          tools={[
+          tools={
+            /*
             <NavLink
               className="pf-c-button pf-m-primary"
               to={'/create-connector'}
@@ -150,7 +150,9 @@ export const ConnectorInstancesTable: FunctionComponent<
             >
               {t('createConnectorsInstance')}
             </NavLink>,
-          ]}
+          */
+            undefined
+          }
           itemCount={itemCount}
           page={page}
           perPage={size}


### PR DESCRIPTION
This change disables or removes buttons from the entry page as well as adds redirects to the create/duplicate app paths so that connector instances cannot be created via the UI.